### PR TITLE
Use same prefix convention for python as with ruby and perl.

### DIFF
--- a/waflib/Tools/python.py
+++ b/waflib/Tools/python.py
@@ -461,7 +461,7 @@ def check_python_version(conf, minver=None):
 					   "get_python_lib(standard_lib=0) or ''"])
 			else:
 				python_LIBDEST = None
-				(pydir,) = conf.get_python_variables( ["get_python_lib(standard_lib=0) or ''"])
+				(pydir,) = conf.get_python_variables( ["get_python_lib(standard_lib=0, prefix='%s') or ''" % conf.env['PREFIX']])
 			if python_LIBDEST is None:
 				if conf.env['LIBDIR']:
 					python_LIBDEST = os.path.join(conf.env['LIBDIR'], "python" + pyver)
@@ -476,7 +476,7 @@ def check_python_version(conf, minver=None):
 			pyarchdir = conf.environ['PYTHONARCHDIR']
 		else:
 			# Finally, try to guess
-			(pyarchdir, ) = conf.get_python_variables( ["get_python_lib(plat_specific=1, standard_lib=0) or ''"])
+			(pyarchdir, ) = conf.get_python_variables( ["get_python_lib(plat_specific=1, standard_lib=0, prefix='%s') or ''" % conf.env['PREFIX']])
 			if not pyarchdir:
 				pyarchdir = pydir
 


### PR DESCRIPTION
Should /usr/local/.../site-packages not be in sys.path in some
platform, a user would pass --pythondir, and --pythonarchdir to
waf when compiling, or modify sys.path.

This makes waf work more predictable, as when passing --prefix
parameter to the build, everything will be installed under this
directory.