### PR TITLE
cpplint: fixed import.

### DIFF
--- a/waflib/extras/cpplint.py
+++ b/waflib/extras/cpplint.py
@@ -49,7 +49,7 @@ import logging
 import threading
 from waflib import Task, Build, TaskGen, Logs, Utils
 try:
-    from cpplint.cpplint import ProcessFile, _cpplint_state
+    from cpplint import ProcessFile, _cpplint_state
 except ImportError:
     pass
 


### PR DESCRIPTION
cpplint: fixed import. The version on pypi is now up to date and works with Python3.