### PR TITLE
cpplint: keep the old import

### DIFF
--- a/waflib/extras/cpplint.py
+++ b/waflib/extras/cpplint.py
@@ -49,9 +49,12 @@ import logging
 import threading
 from waflib import Task, Build, TaskGen, Logs, Utils
 try:
-    from cpplint import ProcessFile, _cpplint_state
+    from cpplint.cpplint import ProcessFile, _cpplint_state
 except ImportError:
-    pass
+    try:
+        from cpplint import ProcessFile, _cpplint_state
+    except ImportError:
+        pass
 
 
 critical_errors = 0


### PR DESCRIPTION
cpplint: import first like it did previously. fallback on the new import if it fails.