### PR TITLE
qt5: cope with library names like 'Qt5Core' instead of 'QtCore5'

### DIFF
--- a/waflib/Tools/qt5.py
+++ b/waflib/Tools/qt5.py
@@ -642,7 +642,7 @@ def find_qt5_libraries(self):
 
 				env.append_unique('LIBPATH_' + uselib, qtlibs)
 				env.append_unique('INCLUDES_' + uselib, qtincludes)
-				env.append_unique('INCLUDES_' + uselib, os.path.join(qtincludes, i))
+				env.append_unique('INCLUDES_' + uselib, os.path.join(qtincludes, i.replace('Qt5', 'Qt')))
 
 				# Debug library names are like QtCore5d
 				uselib = i.upper() + "_debug"
@@ -657,7 +657,7 @@ def find_qt5_libraries(self):
 
 				env.append_unique('LIBPATH_' + uselib, qtlibs)
 				env.append_unique('INCLUDES_' + uselib, qtincludes)
-				env.append_unique('INCLUDES_' + uselib, os.path.join(qtincludes, i))
+				env.append_unique('INCLUDES_' + uselib, os.path.join(qtincludes, i.replace('Qt5', 'Qt')))
 	else:
 		for i in self.qt5_vars_debug + self.qt5_vars:
 			self.check_cfg(package=i, args='--cflags --libs', mandatory=False)
@@ -721,7 +721,7 @@ def set_qt5_defines(self):
 	if sys.platform != 'win32':
 		return
 	for x in self.qt5_vars:
-		y = x[2:].upper()
+		y=x.replace('Qt5', 'Qt')[2:].upper()
 		self.env.append_unique('DEFINES_%s' % x.upper(), 'QT_%s_LIB' % y)
 		self.env.append_unique('DEFINES_%s_DEBUG' % x.upper(), 'QT_%s_LIB' % y)
 


### PR DESCRIPTION
In Qt 5.4 on Windows, wrong include paths and defines were added to the compiler command line due to the naming of the Qt 5.4 libraries.  For example, a library is named 'Qt5Core.lib', but the corresponding include path is still '$QT5_ROOT/include/QtCore'.  The include path provided on the command line was incorrectly given as '$QT5_ROOT/include/Qt5Core' instead.   Also, defines such as QT_CORE_LIB were appearing as QT_5CORE_LIB.