### PR TITLE
Fix a bug for Vala when two tasks share build files.

### DIFF
--- a/waflib/Tools/vala.py
+++ b/waflib/Tools/vala.py
@@ -32,7 +32,7 @@ class valac(Task.Task):
 
 		for x in self.outputs:
 			if id(x.parent) != id(self.outputs[0].parent):
-				shutil.move(self.outputs[0].parent.abspath() + os.sep + x.name, x.abspath())
+				shutil.copy(self.outputs[0].parent.abspath() + os.sep + x.name, x.abspath())
 
 		if self.generator.dump_deps_node:
 			self.generator.dump_deps_node.write('\n'.join(self.generator.packages))


### PR DESCRIPTION
If two tasks, let's say a shared and a static library, share the same
sources `*.vala`, they will generate the same `*.c` files, but since it's
part of the valac task to move these files, they won't be available for
the second task.

This is a naive fix that simply replaces `shutil.move` for `shutil.copy`.
A good fix would probably generate the files at the right locations and
simply avoiding the move call.