### PR TITLE
Change with shared library compatibility version handling

### DIFF
--- a/demos/c++/wscript
+++ b/demos/c++/wscript
@@ -19,6 +19,8 @@ def configure(conf):
 
 def build(bld):
 	bld.shlib(source='a.cpp', target='mylib', vnum='9.8.7')
+	bld.shlib(source='a.cpp', target='mylib2', vnum='9.8.7', cnum='9.8')
+	bld.shlib(source='a.cpp', target='mylib3')
 	bld.program(source='main.cpp', target='app', use='mylib')
 	bld.stlib(target='foo', source='b.cpp')
 

--- a/waflib/Tools/fc_config.py
+++ b/waflib/Tools/fc_config.py
@@ -93,7 +93,7 @@ def fortran_modifier_darwin(conf):
 	"""
 	v = conf.env
 	v['FCFLAGS_fcshlib']   = ['-fPIC']
-	v['LINKFLAGS_fcshlib'] = ['-dynamiclib', '-Wl,-compatibility_version,1', '-Wl,-current_version,1']
+	v['LINKFLAGS_fcshlib'] = ['-dynamiclib']
 	v['fcshlib_PATTERN']   = 'lib%s.dylib'
 	v['FRAMEWORKPATH_ST']  = '-F%s'
 	v['FRAMEWORK_ST']      = '-framework %s'

--- a/waflib/Tools/gcc.py
+++ b/waflib/Tools/gcc.py
@@ -97,7 +97,7 @@ def gcc_modifier_darwin(conf):
 	"""Configuration flags for executing gcc on MacOS"""
 	v = conf.env
 	v['CFLAGS_cshlib']       = ['-fPIC']
-	v['LINKFLAGS_cshlib']    = ['-dynamiclib', '-Wl,-compatibility_version,1', '-Wl,-current_version,1']
+	v['LINKFLAGS_cshlib']    = ['-dynamiclib']
 	v['cshlib_PATTERN']      = 'lib%s.dylib'
 	v['FRAMEWORKPATH_ST']    = '-F%s'
 	v['FRAMEWORK_ST']        = ['-framework']

--- a/waflib/Tools/gxx.py
+++ b/waflib/Tools/gxx.py
@@ -97,7 +97,7 @@ def gxx_modifier_darwin(conf):
 	"""Configuration flags for executing g++ on MacOS"""
 	v = conf.env
 	v['CXXFLAGS_cxxshlib']   = ['-fPIC']
-	v['LINKFLAGS_cxxshlib']  = ['-dynamiclib', '-Wl,-compatibility_version,1', '-Wl,-current_version,1']
+	v['LINKFLAGS_cxxshlib']  = ['-dynamiclib']
 	v['cxxshlib_PATTERN']    = 'lib%s.dylib'
 	v['FRAMEWORKPATH_ST']    = '-F%s'
 	v['FRAMEWORK_ST']        = ['-framework']


### PR DESCRIPTION
For ELF binaries (e.g., Linux): default compatible version (SONAME =
`<library-name>.so.<MAJOR>`) can be specialized using additional `cnum`
parameter to `<library-name>.so.<MAJOR>.<MINOR>` or
`<library-name>.so.<MAJOR>.<MINOR>.<PATCH>`.

For Mach-O binaries (e.g., OS X):

- (bugfix) install-name points to compatible version (not absolute path
  to a non-versioned library)
- Default install-name `<install-path>/<library-name>.<MAJOR>.dylib` can
  be specialized using `cnum` parameter to
  `<install-path>/<library-name>.<MAJOR>.<MINOR>.dylib` or
  `<install-path>/<library-name>.<MAJOR>.<MINOR>.<PATCH>.dylib`
- `-Wl,-compatibility_version` and `-Wl,-current_version` flags use
  version from cnum/vnum (default cnum is `vnum.split('.')[0]`)
- When `vnum` is not specified, `-Wl,-compatibility_version` and `-Wl,-current_version` are not set (both are 0.0.0, instead of previously hard-coded 1.0.0)