### PR TITLE
Add tooldir to cache-check on loading module in Configure context.

### DIFF
--- a/waflib/Configure.py
+++ b/waflib/Configure.py
@@ -252,7 +252,7 @@ class ConfigurationContext(Context.Context):
 			# avoid loading the same tool more than once with the same functions
 			# used by composite projects
 
-			mag = (tool, id(self.env), funs)
+			mag = (tool, id(self.env), tooldir, funs)
 			if mag in self.tool_cache:
 				self.to_log('(tool %s is already loaded, skipping)' % tool)
 				continue


### PR DESCRIPTION
Currently, attempting to load a tool in the ```Configure``` context enters it into a cache and prevents further attempts at loading it, regardless of the ```tooldir``` argument. This prevents users from attempting to load the tool from somewhere else, if an initial attempt at loading the tool fails.

The approach taken in this PR allows repeated load attempts from different ```tooldir```s. An alternative approach would be to only enter the tool into the cache if the load attempt succeeds, which may or may not be more desirable.