### PR TITLE
ConfigSet propsed new methods

### DIFF
--- a/waflib/ConfigSet.py
+++ b/waflib/ConfigSet.py
@@ -131,6 +131,14 @@ class ConfigSet(object):
 		else:
 			del self[name]
 
+	def __iter__(self):
+		merged_table=self.get_merged_dict()
+		return iter(merged_table)
+
+	def iteritems(self):
+		merged_table=self.get_merged_dict()
+		return merged_table.iteritems()
+
 	def derive(self):
 		"""
 		Returns a new ConfigSet deriving from self. The copy returned

--- a/waflib/ConfigSet.py
+++ b/waflib/ConfigSet.py
@@ -340,3 +340,15 @@ class ConfigSet(object):
 		"""
 		self.table = self.undo_stack.pop(-1)
 
+	def deepcopy(self):
+		"""
+		Create a deep copy (as opposed to .derive) of this ConfigSet.
+		"""
+		merged_table=self.get_merged_dict()
+
+		other = ConfigSet()
+		for key, value in merged_table.iteritems():
+			if key!='undo_stack':
+				other[key] = copy.deepcopy(value)
+		return other
+


### PR DESCRIPTION
I'd like to propose fw new methods for ConfigSet.

The first two are related to the ConfigSet's dict interface. They are __iter__ and iteritems.
They do exactly what their counterparts in a standard dict do.

```python
def configure(conf):
        for k in common_env:
            print k

        for k, v, in common_env.iteritems():
            print k, v
```

the last method allows a deep copy of a ConfigSet object.

consider this configure:
I'd like to use conf.env as a shared, common environment and change only the relevant parts in any subsequent variants.

```python
def configure(conf):
        conf.env["AAAA"] = "Whatever"
        conf.load('compiler_c')
        conf.env.CFLAGS = []

        conf.setenv('release', conf.env.derive())
        conf.env.CFLAGS += ['-O2']

        conf.setenv('debug', conf.env.derive())
        conf.env.CFLAGS += ['-g']

        conf.setenv('special', conf.env.derive())
        conf.env.CFLAGS.append("Special")
```

Unfortunately I will end up with the same 3 environments here, because derive() creates only a shallow copy. In fact in this example derive() is completely useless as I'm changing yes a different ConfigSet, but all of them shares the same objects.

consider this instead:

```python
def configure(conf):
    conf.env["AAAA"] = "Whatever"
    conf.load('compiler_c')
    conf.env.CFLAGS = []

    common_env = conf.env.deepcopy()
    
    conf.setenv('release', common_env.deepcopy())
    conf.env.CFLAGS += ['-O2']
    
    conf.setenv('debug', common_env.deepcopy())
    conf.env.CFLAGS += ['-g']
    
    conf.setenv('special', common_env.deepcopy())
    conf.env.CFLAGS.append("Special")
 ```

this will allow me to load a tool, compiler_c in this example, only once, then settings some common environments variable.
Later I can copy the common environment for each new variant being sure that they will not interfere with each other environment. 


