### PR TITLE
Disable regular sys.path when loading tool with specified tooldir.

### DIFF
--- a/waflib/Configure.py
+++ b/waflib/Configure.py
@@ -234,7 +234,7 @@ class ConfigurationContext(Context.Context):
 			tmpenv = self.all_envs[key]
 			tmpenv.store(os.path.join(self.cachedir.abspath(), key + Build.CACHE_SUFFIX))
 
-	def load(self, input, tooldir=None, funs=None):
+	def load(self, input, tooldir=None, funs=None, loadFromSysPath=True):
 		"""
 		Load Waf tools, which will be imported whenever a build is started.
 
@@ -260,7 +260,7 @@ class ConfigurationContext(Context.Context):
 
 			module = None
 			try:
-				module = Context.load_tool(tool, tooldir, ctx=self)
+				module = Context.load_tool(tool, tooldir, ctx=self, loadFromSysPath=loadFromSysPath)
 			except ImportError as e:
 				self.fatal('Could not load the Waf tool %r from %r\n%s' % (tool, sys.path, e))
 			except Exception as e:

--- a/waflib/Context.py
+++ b/waflib/Context.py
@@ -621,8 +621,8 @@ def load_module(path, encoding=None):
 	module_dir = os.path.dirname(path)
 	sys.path.insert(0, module_dir)
 
-	exec(compile(code, path, 'exec'), module.__dict__)
-	sys.path.remove(module_dir)
+	try    : exec(compile(code, path, 'exec'), module.__dict__)
+	finally: sys.path.remove(module_dir)
 
 	cache_modules[path] = module
 


### PR DESCRIPTION
Currently, when a user attempts to load a waf tool, waf will load any module with the given name, which can be found on ```sys.path```. Specifying a ```tooldir``` does prevent loading from ```waflib.Tools``` and ```waflib.extras```, but not from any location already on the path.

The ability to load waf tools from site packages and other locations on the path may be desired in general, but searching the path, even when ```tooldir``` is specified, breaks my use case of first attempting to load a tool from a specific directory and then falling back to the standard waf tools, if that fails. In my case, a *python module* gets loaded from ```sys.path```, instead of the *waf tool*, which I want.

To me, when specifying a ```tooldir``` the search behaviour should **either** be _identical_ to the normal behaviour, except for _also_ searching the specified directory **or** it should _only_ search the specified directory. This PR implements the latter behaviour.

Alternatively, I could
* implement a version which implements the former behaviour,
* or one which disables searching the standard ```sys.path```, via an optional argument to ```ctx.load()```,
* or one which disables searching the standard ```sys.path``` altogether.

Let me know if you would prefer any of those. They would all solve my problem.