### PR TITLE
improve error reporting for Fortran programs and libraries

### DIFF
--- a/waflib/Tools/c_aliases.py
+++ b/waflib/Tools/c_aliases.py
@@ -5,8 +5,10 @@
 "base for all c/c++ programs and libraries"
 
 import os, sys, re
-from waflib import Utils, Build
+from waflib import Utils, Build, Errors
 from waflib.Configure import conf
+
+LINKING_FEATURES = ('c','cxx','d','fc','asm')
 
 def get_extensions(lst):
 	"""
@@ -69,6 +71,21 @@ def sniff_features(**kw):
 def set_features(kw, _type):
 	kw['_type'] = _type
 	kw['features'] = Utils.to_list(kw.get('features', [])) + Utils.to_list(sniff_features(**kw))
+
+	if _type in ('program', 'shlib', 'stlib'):
+		# Make sure that a linking feature and a feature matching the type
+		# has been specified
+		for feat in kw['features']:
+			if feat in LINKING_FEATURES:
+				break
+		else:
+			raise Exception("A linking feature (one of %s) must be specified." % (", ".join(LINKING_FEATURES)))
+
+		for feat in kw['features']:
+			if feat.endswith(_type):
+				break
+		else:
+			raise Exception("A %s type (e.g. c%s or fc%s) must be specified in features." % (_type, _type, _type))
 
 @conf
 def program(bld, *k, **kw):

--- a/waflib/Tools/ccroot.py
+++ b/waflib/Tools/ccroot.py
@@ -181,7 +181,7 @@ def rm_tgt(cls):
 	setattr(cls, 'run', wrap)
 rm_tgt(stlink_task)
 
-@feature('c', 'cxx', 'd', 'fc', 'asm')
+@feature(*c_aliases.LINKING_FEATURES)
 @after_method('process_source')
 def apply_link(self):
 	"""


### PR DESCRIPTION
This change makes bld.program, bld.stlib and bld.shlib throw exceptions
if there is no link task or if a feature of the proper type isn't
specified.