### PR TITLE
c_config: Avoid warnings/errors when checking for C functions

### DIFF
--- a/waflib/Tools/c_config.py
+++ b/waflib/Tools/c_config.py
@@ -25,10 +25,10 @@ cfg_ver = {
 
 SNIP_FUNCTION = '''
 int main(int argc, char **argv) {
-	void *p;
+	void (*p)();
 	(void)argc; (void)argv;
-	p=(void*)(%s);
-	return (int)p;
+	p=(void(*)())(%s);
+	return !p;
 }
 '''
 """Code template for checking for functions"""


### PR DESCRIPTION
  The check for C functions fails with '-Werror' in GCC (5.2).

The cast here triggers an error:
```
  return (int)p;
```

    error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]

The conversion here triggers another error with '-pedantic -Werror':
```
  p=(void*)(%s);
````

    error: ISO C forbids conversion of function pointer to object pointer type [-Werror=pedantic]

This patch fixes both errors.

Signed-off-by: Mohammad Alsaleh <CE.Mohammad.AlSaleh@gmail.com>