### PR TITLE
Don't save MSVC_INSTALLED_VERSIONS for lazy detection

### DIFF
--- a/waflib/Tools/msvc.py
+++ b/waflib/Tools/msvc.py
@@ -383,7 +383,7 @@ class lazytup(object):
 	def evaluate(self):
 		if hasattr(self, 'value'):
 			return
-		self.value = self.fn()		
+		self.value = self.fn()
 
 @conf
 def gather_msvc_targets(conf, versions, version, vc_path):
@@ -606,14 +606,20 @@ def get_msvc_versions(conf):
 	:return: list of compilers installed
 	:rtype: list of string
 	"""
-	if not conf.env['MSVC_INSTALLED_VERSIONS']:
-		lst = []
-		conf.gather_icl_versions(lst)
-		conf.gather_intel_composer_versions(lst)
-		conf.gather_wsdk_versions(lst)
-		conf.gather_msvc_versions(lst)
+	if conf.env['MSVC_INSTALLED_VERSIONS']:
+		return conf.env['MSVC_INSTALLED_VERSIONS']
+
+	lst = []
+	conf.gather_icl_versions(lst)
+	conf.gather_intel_composer_versions(lst)
+	conf.gather_wsdk_versions(lst)
+	conf.gather_msvc_versions(lst)
+
+	lazy = getattr(Options.options, 'msvc_lazy_autodetect', False) or conf.env['MSVC_LAZY_AUTODETECT']
+	if not lazy:
 		conf.env['MSVC_INSTALLED_VERSIONS'] = lst
-	return conf.env['MSVC_INSTALLED_VERSIONS']
+
+	return lst
 
 @conf
 def print_all_msvc_detected(conf):


### PR DESCRIPTION
This branch includes two patches. The first disables saving MSVC_INSTALLED_VERSIONS after lazy detection, because in that case the targets have not all been evaluated and so there are a lot of empties--see #1611.

The second updates get_msvc_versions to evaluate all targets if called directly. This enables saving MSVC_INSTALLED_VERSIONS and printing them even if lazy detection is otherwise set. Note the other gather_* functions still return the full list of lazytups if called directly.

Neither one of these is strictly needed for anything I'm doing, but if it's an improvement over the behavior currently in master, feel free to take it.