### PR TITLE
Consolidate mobile targets

### DIFF
--- a/waflib/Tools/msvc.py
+++ b/waflib/Tools/msvc.py
@@ -467,9 +467,14 @@ def gather_msvc_versions(conf, versions):
 		if wince_supported_platforms and os.path.isfile(vsvars):
 			conf.gather_wince_targets(versions, version, vc_path, vsvars, wince_supported_platforms)
 
+	# WP80 works with 11.0Exp and 11.0, both of which resolve to the same vc_path.
+	# Stop after one is found.
+	for version,vc_path in vc_paths:
+		vs_path = os.path.dirname(vc_path)
 		vsvars = os.path.join(vs_path, 'VC', 'WPSDK', 'WP80', 'vcvarsphoneall.bat')
 		if os.path.isfile(vsvars):
 			conf.gather_winphone_targets(versions, '8.0', vc_path, vsvars)
+			break
 
 	for version,vc_path in vc_paths:
 		vs_path = os.path.dirname(vc_path)

--- a/waflib/Tools/msvc.py
+++ b/waflib/Tools/msvc.py
@@ -283,12 +283,12 @@ def gather_wince_supported_platforms():
 		path,device = os.path.split(path)
 		if not device:
 			path,device = os.path.split(path)
+		platforms = []
 		for arch,compiler in all_wince_platforms:
-			platforms = []
 			if os.path.isdir(os.path.join(path, device, 'Lib', arch)):
 				platforms.append((arch, compiler, os.path.join(path, device, 'Include', arch), os.path.join(path, device, 'Lib', arch)))
-			if platforms:
-				supported_wince_platforms.append((device, platforms))
+		if platforms:
+			supported_wince_platforms.append((device, platforms))
 	return supported_wince_platforms
 
 def gather_msvc_detected_versions():


### PR DESCRIPTION
This branch in two patches fixes the structure of WinCE and winphone targets in the versions list. See #1616. I am not addressing the issue mentioned in which additional environment variables are needed to successfully configure and build. Someone with a working project to test or knowledge of exactly what paths need to end up in the config set would need to address that part.