### PR TITLE
Update the pic build flag used for Sun CC

### DIFF
--- a/waflib/Tools/suncc.py
+++ b/waflib/Tools/suncc.py
@@ -53,7 +53,7 @@ def scc_common_flags(conf):
 	v['cprogram_PATTERN']    = '%s'
 
 	# shared library
-	v['CFLAGS_cshlib']       = ['-Kpic', '-DPIC']
+	v['CFLAGS_cshlib']       = ['-xcode=pic32', '-DPIC']
 	v['LINKFLAGS_cshlib']    = ['-G']
 	v['cshlib_PATTERN']      = 'lib%s.so'
 
@@ -68,4 +68,3 @@ def configure(conf):
 	conf.cc_load_tools()
 	conf.cc_add_flags()
 	conf.link_add_flags()
-


### PR DESCRIPTION
`-Kpic` had been used to generate position-indenpendent code for Sun CC.
This permits only 2^10 unqiue symbols per shared object on 64-bit
systems.  This is an unreasonably small default. Switching to `-KPIC`
increases the number to 2^29.

According to
http://docs.oracle.com/cd/E37069_01/html/E37074/bjapp.html#OSSCGbjatt,
both `-Kpic` and `-KPIC` have been deprecated, and the `-xcode` option
should be used instead. `-xcode` has been available since at least Sun
Studio 8.