### PR TITLE
Select HTML theme depending on Sphinx version.

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -396,8 +396,11 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-from sphinx import version_info
-if (1, 3) <= version_info:
+try:
+	from sphinx import version_info
+except ImportError:
+	version_info = None
+if version_info and (1, 3) <= version_info:
 	html_theme = 'classic'
 else:
 	html_theme = 'default'

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -396,7 +396,11 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'classic'
+from sphinx import version_info
+if (1, 3) <= version_info:
+	html_theme = 'classic'
+else:
+	html_theme = 'default'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
The 'default' theme has been renamed to 'classic' for Sphinx >= 1.3.

This should fix #1645.