### PR TITLE
Node JSON functions

### DIFF
--- a/playground/json/test.json
+++ b/playground/json/test.json
@@ -1,0 +1,9 @@
+{
+  "array": [1, 2, "abc", 4.8, null],
+  "dict": {
+    "integer": 1,
+    "float": 4.8,
+    "string": "Hello, world!"
+  },
+  "boolean": true
+}

--- a/playground/json/wscript
+++ b/playground/json/wscript
@@ -1,0 +1,32 @@
+#! /usr/bin/env python
+# encoding: utf-8
+# Matt Clarkson, 2015 (ita)
+
+VERSION='0.0.1'
+APPNAME='json_test'
+
+top = '.'
+
+import sys
+import waflib.Configure
+waflib.Configure.autoconfig = True
+
+def options(opt):
+	opt.add_option(
+		'--pretty',
+		action  = 'store_true',
+		help    = 'pretty prints the writing of the JSON')
+
+def configure(conf):
+	pass
+
+def build(bld):
+	node = bld.srcnode.make_node('test.json')
+	json = node.read_json()
+	print('Read', json)
+	json['new_key'] = {
+		'number': 199
+	}
+	output = bld.bldnode.make_node('output.json')
+	output.write_json(json, pretty=bld.options.pretty)
+	print('Wrote', output.read())

--- a/waflib/Node.py
+++ b/waflib/Node.py
@@ -20,7 +20,7 @@ Node: filesystem structure, contains lists of nodes
    (:py:class:`waflib.Node.Nod3`, see the :py:class:`waflib.Context.Context` initializer). A reference to the context owning a node is held as self.ctx
 """
 
-import os, re, sys, shutil
+import os, re, sys, shutil, json
 from waflib import Utils, Errors
 
 exclude_regs = '''
@@ -134,6 +134,40 @@ class Node(object):
 		:return: File contents
 		"""
 		return Utils.readf(self.abspath(), flags, encoding)
+
+	def read_json(self, convert=True, encoding='utf-8'):
+		"""
+		Read and parse the contents of this node as JSON::
+
+			def build(bld):
+				bld.path.find_node('abc.json').read_json()
+
+		Note that this by default automatically decodes unicode strings on Python2, unlike what the Python JSON module does.
+
+		:type  convert: boolean
+		:param convert: Prevents decoding of unicode strings on Python2
+		:type  encoding: string
+		:param encoding: The encoding of the file to read. This default to UTF8 as per the JSON standard
+		:rtype: object
+		:return: Parsed file contents
+		"""
+		object_pairs_hook = None
+
+		if convert and sys.hexversion < 0x3000000:
+			def convert(value):
+				if isinstance(value, list):
+					return [convert(element) for element in value]
+				elif isinstance(value, unicode):
+					return str(value)
+				else:
+					return value
+
+			def object_pairs(pairs):
+				return dict((str(pair[0]), convert(pair[1])) for pair in pairs)
+
+			object_pairs_hook = object_pairs
+
+		return json.loads(self.read(encoding=encoding), object_pairs_hook=object_pairs_hook)
 
 	def write(self, data, flags='w', encoding='ISO8859-1'):
 		"""

--- a/waflib/Node.py
+++ b/waflib/Node.py
@@ -183,6 +183,29 @@ class Node(object):
 		"""
 		Utils.writef(self.abspath(), data, flags, encoding)
 
+	def write_json(self, data, pretty=True):
+		"""
+		Writes a python object as JSON to disk. Files are always written as UTF8 as per the JSON standard::
+
+			def build(bld):
+				bld.path.find_node('xyz.json').write_json(199)
+
+		:type  data: object
+		:param data: The data to write to disk
+		:type  pretty: boolean
+		:param pretty: Determines if the JSON will be nicely space separated
+		"""
+		indent = 2
+		separators = (',', ': ')
+		sort_keys = pretty
+		newline = os.linesep
+		if not pretty:
+			indent = None
+			separators = (',', ':')
+			newline = ''
+		output = json.dumps(data, indent=indent, separators=separators, sort_keys=sort_keys) + newline
+		self.write(output, encoding='utf-8')
+
 	def chmod(self, val):
 		"""
 		Change file/dir permissions::


### PR DESCRIPTION
This adds `write_json` and `read_json` functions to the Node class.

You can run the playground example with `../../waf-light`:

```
[waf/playground/json] python2 ../../waf-light
Waf: Entering directory `/home/matt/git/github/waf-project/waf/playground/json/build'
('Read', {'array': [1, 2, 'abc', 4.8, None], 'boolean': True, 'dict': {'integer': 1, 'float': 4.8, 'string': 'Hello, world!'}})
('Wrote', '{"new_key":{"number":199},"array":[1,2,"abc",4.8,null],"boolean":true,"dict":{"integer":1,"float":4.8,"string":"Hello, world!"}}')
Waf: Leaving directory `/home/matt/git/github/waf-project/waf/playground/json/build'
'build' finished successfully (0.004s)
[waf/playground/json] python3 ../../waf-light
Waf: Entering directory `/home/matt/git/github/waf-project/waf/playground/json/build'
Read {'dict': {'string': 'Hello, world!', 'float': 4.8, 'integer': 1}, 'boolean': True, 'array': [1, 2, 'abc', 4.8, None]}
Wrote {"dict":{"string":"Hello, world!","float":4.8,"integer":1},"boolean":true,"array":[1,2,"abc",4.8,null],"new_key":{"number":199}}
Waf: Leaving directory `/home/matt/git/github/waf-project/waf/playground/json/build'
'build' finished successfully (0.003s)
```