### PR TITLE
Add vbldnode to ConfigurationContext

### DIFF
--- a/waflib/Configure.py
+++ b/waflib/Configure.py
@@ -99,6 +99,15 @@ class ConfigurationContext(Context.Context):
 
 	env = property(get_env, set_env)
 
+	def get_vbldnode(self):
+		"""Getter for the vbldnode property"""
+		if not self.variant:
+			return self.bldnode
+		return self.bldnode.make_node(self.variant)
+
+	vbldnode = property(get_vbldnode, None)
+	"""Node that would be used by a variant build as bldnode"""
+
 	def init_dirs(self):
 		"""
 		Initialize the project directory and the build directory


### PR DESCRIPTION
Sometimes during configuration is necessary to know where the variant build is
for the current env. One example would be configuring external build system.

This addresses issue #1668 