### PR TITLE
c_config: Don't append library names uniquely

### DIFF
--- a/waflib/Tools/c_config.py
+++ b/waflib/Tools/c_config.py
@@ -159,7 +159,7 @@ def parse_flags(self, line, uselib_store, env=None, force_static=False, posix=No
 		elif st == '-l':
 			if not ot: ot = lst.pop(0)
 			prefix = (force_static or static) and 'STLIB_' or 'LIB_'
-			appu(prefix + uselib, [ot])
+			app(prefix + uselib, [ot])
 		elif st == '-L':
 			if not ot: ot = lst.pop(0)
 			prefix = (force_static or static) and 'STLIBPATH_' or 'LIBPATH_'


### PR DESCRIPTION
 Sometimes, we need to pass a library name to a linker twice to handle
 circular dependencies.