### PR TITLE
Regex change proposed by apthorpe

### DIFF
--- a/waflib/Tools/ifort.py
+++ b/waflib/Tools/ifort.py
@@ -37,7 +37,7 @@ def ifort_modifier_platform(conf):
 def get_ifort_version(conf, fc):
 	"""get the compiler version"""
 
-	version_re = re.compile(r"Intel[\sa-zA-Z()0-9,-]*Version\s*(?P<major>\d*)\.(?P<minor>\d*)",re.I).search
+	version_re = re.compile(r"\bIntel\b.*\bVersion\s*(?P<major>\d*)\.(?P<minor>\d*)",re.I).search
 	if Utils.is_win32:
 		cmd = fc
 	else:


### PR DESCRIPTION
as discussed in #1672 this change loosens and simplifies the regex for the version string of the ifort. It works at least with Intel 15 on Linux 64 bit.