### PR TITLE
Do not set the ARFLAGS unconditionally to rcs for ifort.

### DIFF
--- a/waflib/Tools/ifort.py
+++ b/waflib/Tools/ifort.py
@@ -53,7 +53,7 @@ def get_ifort_version(conf, fc):
 def configure(conf):
 	conf.find_ifort()
 	conf.find_program('xiar', var='AR')
-	conf.env.ARFLAGS = 'rcs'
+	conf.find_ar()
 	conf.fc_flags()
 	conf.fc_add_flags()
 	conf.ifort_modifier_platform()


### PR DESCRIPTION
Instead, try invoke search for ar after looking for xiar.

Ifort comes with its own archiver which is required for interprocedural optimizations, if I remember correctly. This archiver xiar would be preferred to use for ifort, thus the configure for ifort looked for xiar instead of using find_ar. However, it also set unconditionally the ARFLAGS to rcs, which causes trouble if the archiver is not actually xiar and the user gets robbed of the possibility to set those flags manually. This change now removes the unconditional setting of rcs and instead invokes find_ar to look for the archiver if it was not already found and sets the flags accordingly.
I hope this is the correct way to go about.

Maybe the find_ar should instead take an argument for the archiver name to look for?