### PR TITLE
add empty check for inst.exec_install_as()

### DIFF
--- a/waflib/Build.py
+++ b/waflib/Build.py
@@ -879,7 +879,8 @@ class inst(Task.Task):
 		Predefined method for installing one file with a given name
 		"""
 		destfile = self.get_install_path()
-		self.generator.bld.do_install(self.inputs[0].abspath(), destfile, chmod=self.chmod, tsk=self)
+		if self.inputs:
+			self.generator.bld.do_install(self.inputs[0].abspath(), destfile, chmod=self.chmod, tsk=self)
 
 	def exec_symlink_as(self):
 		"""


### PR DESCRIPTION
similar as exec_install_files(), exec_install_as() should check empty for self.inputs.

It causes exception if the inst is not posted.