### PR TITLE
Fixing version flag for NAG compiler.

### DIFF
--- a/waflib/extras/fc_nag.py
+++ b/waflib/extras/fc_nag.py
@@ -36,7 +36,7 @@ def get_nag_version(conf, fc):
 	"""Get the NAG compiler version"""
 
 	version_re = re.compile(r"^NAG Fortran Compiler *Release *(?P<major>\d*)\.(?P<minor>\d*)", re.M).search
-	cmd = fc + ['-v']
+	cmd = fc + ['-V']
 
 	out, err = fc_config.getoutput(conf,cmd,stdin=False)
 	if out:


### PR DESCRIPTION
The nagfor compiler (as of current version 6.0) uses according to the man page the option `-V` to query compiler version. Waf uses `-v` instead, where nagfor expects also a source file name at the command line and generates an exit code != 0 when not present. This caused in waf 1.8.17 failure when detecting nagfor. Although recent patches in `fc_config.py` work around this by accepting non-zero exit codes, one should probably still use the correct flag. 