### PR TITLE
Set FC_NAME also in find_ifort_win32.

### DIFF
--- a/waflib/Tools/ifort.py
+++ b/waflib/Tools/ifort.py
@@ -388,6 +388,8 @@ def find_ifort_win32(conf):
 	if not conf.cmd_and_log(fc + ['/nologo', '/help'], env=env):
 		conf.fatal('not intel fortran compiler could not be identified')
 
+	v['FC_NAME'] = 'IFORT'
+
 	# linker
 	if not v['LINK_FC']:
 		conf.find_program(linker_name, var='LINK_FC', path_list=path, mandatory=True)


### PR DESCRIPTION
So, here is what I did to fix my setting. I think it would be good to set this, as all Fortran compilers provide it and it would be a little surprising to not have it for ifort on windows. However, in my wscript I anyway need to check for win or not. Thus, it is not strictly necessary to have this.