### PR TITLE
Do chmod in netcache post_run

### DIFF
--- a/waflib/extras/netcache_client.py
+++ b/waflib/extras/netcache_client.py
@@ -337,6 +337,9 @@ def make_cached(cls):
 		ret = m2(self)
 		if bld.cache_global:
 			self.put_files_cache()
+		if hasattr(self, 'chmod'):
+			for node in self.outputs:
+				os.chmod(node.abspath(), self.chmod)
 		return ret
 	cls.post_run = post_run
 


### PR DESCRIPTION
This ensures that, for example, executable files that are fetched from
the cache end up with the right permissions.