### PR TITLE
No-op in netcache run/post_run if nocache is true

### DIFF
--- a/waflib/extras/netcache_client.py
+++ b/waflib/extras/netcache_client.py
@@ -326,6 +326,8 @@ def make_cached(cls):
 
 	m1 = cls.run
 	def run(self):
+		if getattr(self, 'nocache', False):
+			return m1(self)
 		if self.can_retrieve_cache():
 			return 0
 		return m1(self)
@@ -333,6 +335,8 @@ def make_cached(cls):
 
 	m2 = cls.post_run
 	def post_run(self):
+		if getattr(self, 'nocache', False):
+			return m2(self)
 		bld = self.generator.bld
 		ret = m2(self)
 		if bld.cache_global:


### PR DESCRIPTION
When a task class has a true value for the nocache attribute,
setup_nocache doesn't decorate the run() and post_run() methods of the
class. In most cases, however, that's not enough to disable caching
because the base Task class is still modified; any class based on Task
which doesn't override these methods will still use caching even if it
sets nocache to True. This is solved by having the decorated versions of
run() and post_run() do nothing except call the original version of the
method when the task object has a true value for self.nocache.