### PR TITLE
Make D dependency scanner aware of package.d files

### DIFF
--- a/waflib/Tools/d_scan.py
+++ b/waflib/Tools/d_scan.py
@@ -108,16 +108,17 @@ class d_parser(object):
 		:param filename: file to read
 		:type filename: string
 		"""
-		found = 0
+		file_path = filename.replace('.', '/')
 		for n in self.incpaths:
-			found = n.find_resource(filename.replace('.', '/') + '.d')
-			if found:
-				self.nodes.append(found)
-				self.waiting.append(found)
-				break
-		if not found:
-			if not filename in self.names:
-				self.names.append(filename)
+			for suffix in ('.d', '/package.d'):
+				found = n.find_resource(file_path + suffix)
+				if found:
+					self.nodes.append(found)
+					self.waiting.append(found)
+					return
+
+		if not filename in self.names:
+			self.names.append(filename)
 
 	def get_strings(self, code):
 		"""


### PR DESCRIPTION
When importing `path.to.module` in D, both `path/to/module.d` and `path/to/module/package.d` should be tried.