### PR TITLE
Boost module enhancements and fixes

### DIFF
--- a/playground/boost_log/main.cpp
+++ b/playground/boost_log/main.cpp
@@ -1,0 +1,11 @@
+#include <boost/log/trivial.hpp>
+
+int main(int, char*[])
+{
+    BOOST_LOG_TRIVIAL(trace) << "A trace severity message";
+    BOOST_LOG_TRIVIAL(debug) << "A debug severity message";
+    BOOST_LOG_TRIVIAL(info) << "An informational severity message";
+    BOOST_LOG_TRIVIAL(warning) << "A warning severity message";
+    BOOST_LOG_TRIVIAL(error) << "An error severity message";
+    BOOST_LOG_TRIVIAL(fatal) << "A fatal severity message";
+}

--- a/playground/boost_log/wscript
+++ b/playground/boost_log/wscript
@@ -1,0 +1,16 @@
+top = '.'
+out = 'build'
+
+def options(opt):
+	opt.load('compiler_cxx boost')
+
+def configure(conf):
+	conf.load('compiler_cxx boost')
+
+	if conf.options.boost_mt:
+		conf.check_boost('system thread log log_setup')
+	else:
+		conf.check_boost('log log_setup')
+
+def build(bld):
+	bld.program(source='main.cpp', target='app', use='BOOST')


### PR DESCRIPTION
- Output detected version of boost in dot-form (e.g., 1.56.0, instead of 1_56)
- Fix Boost.Log library detection:
  * when linking to shared library, BOOST_LOG_DYN_LINK needs to be defined
  * when linking to non-multithreaded version, BOOST_LOG_NO_THREADS needs to be defined

  (see http://www.boost.org/doc/libs/1_60_0/libs/log/doc/html/log/installation/config.html)