### PR TITLE
Fix extra lines in output logs

### DIFF
--- a/waflib/Logs.py
+++ b/waflib/Logs.py
@@ -200,7 +200,7 @@ class formatter(logging.Formatter):
 			c2 = getattr(rec, 'c2', colors.NORMAL)
 			msg = '%s%s%s' % (c1, msg, c2)
 		else:
-			msg = msg.replace('\r', '\n')
+			msg = msg.replace('\r\n', '\n')
 			msg = re.sub(r'\x1B\[(K|.*?(m|h|l))', '', msg)
 
 		if rec.levelno >= logging.INFO: # ??


### PR DESCRIPTION
Replacing '\r' with '\n' in log output on Windows causes an extra blank
line between every line of output.

This was originally added in commit a29f775851a71c4e3516c8531f3b7839d8213f88.

I'm not sure if a replacement is even necessary since removing the line entirely also fixes the problem.