### PR TITLE
Add commit() method to ConfigSet

### DIFF
--- a/waflib/ConfigSet.py
+++ b/waflib/ConfigSet.py
@@ -335,6 +335,12 @@ class ConfigSet(object):
 			tbl[x] = copy.deepcopy(tbl[x])
 		self.undo_stack = self.undo_stack + [orig]
 
+	def commit(self):
+		"""
+		Commits transactional changes. See :py:meth:`ConfigSet.stash`
+		"""
+		self.undo_stack.pop(-1)
+
 	def revert(self):
 		"""
 		Reverts the object to a previous state. See :py:meth:`ConfigSet.stash`


### PR DESCRIPTION
That allows users to use nested transactions.

An very simple example of use is:
```python
def configure(cfg):
    env = cfg.env

    env.stash()
    try:
        env.X = 1

        env.stash()
        try:
            env.Y = 2
        except:
            env.revert()
        else:
            env.commit()

        raise
    except:
        env.revert()
    else:
        env.commit()
```