### PR TITLE
Enable lazy Visual Studio detection by default: one missed spot.

### DIFF
--- a/waflib/Tools/msvc.py
+++ b/waflib/Tools/msvc.py
@@ -653,7 +653,9 @@ def print_all_msvc_detected(conf):
 @conf
 def detect_msvc(conf, arch = False):
 	# Save installed versions only if lazy detection is disabled.
-	lazy_detect = getattr(Options.options, 'msvc_lazy_autodetect', False) or conf.env['MSVC_LAZY_AUTODETECT']
+	lazy_detect = getattr(Options.options, 'msvc_lazy', True)
+	if conf.env['MSVC_LAZY_AUTODETECT'] is False:
+		lazy_detect = False
 	versions = get_msvc_versions(conf, not lazy_detect)
 	return setup_msvc(conf, versions, arch)
 


### PR DESCRIPTION
I noticed the default was still evaluating all msvc targets and tracked it down to a typo in this check.

Changing the conditional was also required to achieve saving MSVC_INSTALLED_VERSIONS to the configuration.

I wonder if the default in `getattr(Options.options, 'msvc_lazy', True)` in a couple places could be removed on the assumption that the option defaults the value at the beginning of the program.