### PR TITLE
Fixes missing backslash for REG_PYTHON_DIR

### DIFF
--- a/utils/waf.bat
+++ b/utils/waf.bat
@@ -43,6 +43,7 @@ REG QUERY "!REGPATH!" /ve 1>nul 2>nul
 if !ERRORLEVEL! equ 0 (
   for /F "%TOKEN% delims=	 " %%A IN ('REG QUERY "!REGPATH!" /ve') do @set REG_PYTHON_DIR=%%B
   if exist !REG_PYTHON_DIR!  (
+    IF NOT "!REG_PYTHON_DIR:~-1!"=="\" SET REG_PYTHON_DIR=!REG_PYTHON_DIR!\
     set REG_PYTHON=!REG_PYTHON_DIR!!REG_PYTHON_EXE!
     rem set PYTHON_DIR_OK=TRUE
     if "!PYTHON_DIR_OK!"=="FALSE" (


### PR DESCRIPTION
Some Windows python distributions (like Anaconda) add a registry entry in InstallPath without a trailing backslash (i.e C:\Python\Anaconda2 rather than C:\Python\Anaconda2**\**)
For those distributions, REG_PYTHON is invalid

- waf.bat configure
- Using C:\Python\Anaconda2python.exe
- '"C:\Python\Anaconda2python.exe"' is not recognized as an internal or external command, operable program or batch file.

This one liner adds a backslash to the directory variable if not present...
