### PR TITLE
fix comment regarding commandline options for swig

### DIFF
--- a/playground/swig/wscript
+++ b/playground/swig/wscript
@@ -39,7 +39,7 @@ def build(bld):
 
 	# embedding
 	#
-	# use swig_flags = '-c++ -python -dump_classes' for debugging
+	# use swig_flags = '-c++ -python -debug-classes' for debugging
 
 	obj = bld(
 		features = 'cxx cxxprogram pyembed',


### PR DESCRIPTION
Fix a comment regarding the commandline options for swig, since '-dump_classes' was renamed to '-debug-classes'. Please see http://www.swig.org/Release/CHANGES for further details.