### PR TITLE
Wrong search patterns generated when recursive doxygen generation is used with default file patterns

### DIFF
--- a/waflib/extras/doxygen.py
+++ b/waflib/extras/doxygen.py
@@ -121,7 +121,7 @@ class doxygen(Task.Task):
 		exclude_patterns = self.pars.get('EXCLUDE_PATTERNS','').split()
 		file_patterns = self.pars.get('FILE_PATTERNS','').split()
 		if not file_patterns:
-			file_patterns = DOXY_FILE_PATTERNS
+			file_patterns = DOXY_FILE_PATTERNS.split()
 		if self.pars.get('RECURSIVE') == 'YES':
 			file_patterns = ["**/%s" % pattern for pattern in file_patterns]
 		nodes = []


### PR DESCRIPTION
DOXY_FILE_PATTERNS is generated as a string but then used as an array when using the RECURSIVE option, therefore the generated patterns for files to be searched are wrong. Convert it into an array with split() therefore to have correct patterns.