### PR TITLE
qt5: Fix usage examples as libraries in qt5 are named QT5XXX and not QTXXX as in qt4 (ie. QT5WIDGETS instead of QTWIDGETS)

### DIFF
--- a/waflib/Tools/qt5.py
+++ b/waflib/Tools/qt5.py
@@ -21,7 +21,7 @@ The following snippet illustrates the tool usage::
 	def build(bld):
 		bld(
 			features = 'qt5 cxx cxxprogram',
-			uselib   = 'QTCORE QTGUI QTOPENGL QTSVG',
+			uselib   = 'QT5CORE QT5GUI QT5OPENGL QT5SVG',
 			source   = 'main.cpp textures.qrc aboutDialog.ui',
 			target   = 'window',
 		)
@@ -328,7 +328,7 @@ def apply_qt5(self):
 	Add MOC_FLAGS which may be necessary for moc::
 
 		def build(bld):
-			bld.program(features='qt5', source='main.cpp', target='app', use='QTCORE')
+			bld.program(features='qt5', source='main.cpp', target='app', use='QT5CORE')
 
 	The additional parameters are:
 


### PR DESCRIPTION

Just fix the documentation examples, as the code is correct and working.