### PR TITLE
Fix: when using the ut_cmd or Option --testcmd, parts of test command line may get lost

### DIFF
--- a/waflib/Tools/waf_unit_test.py
+++ b/waflib/Tools/waf_unit_test.py
@@ -127,7 +127,7 @@ class utest(Task.Task):
 
 		testcmd = getattr(self.generator, 'ut_cmd', False) or getattr(Options.options, 'testcmd', False)
 		if testcmd:
-			self.ut_exec = (testcmd % self.ut_exec[0]).split(' ')
+			self.ut_exec = (testcmd % " ".join(self.ut_exec)).split(' ')
 
 		proc = Utils.subprocess.Popen(self.ut_exec, cwd=cwd, env=self.get_test_env(), stderr=Utils.subprocess.PIPE, stdout=Utils.subprocess.PIPE)
 		(stdout, stderr) = proc.communicate()


### PR DESCRIPTION
Fix: when using the ut_cmd or Option --testcmd, if the test command line has parameters (added for example with the ut_fun method as in the examples) this will be lost as just ut_exec[0] was used. Now join the command line before using it in substition.