### PR TITLE
Fix autoconfig

### DIFF
--- a/waflib/Scripting.py
+++ b/waflib/Scripting.py
@@ -593,7 +593,7 @@ def autoconfigure(execute_method):
 					Options.options.__dict__ = tmp
 			else:
 				run_command(cmd)
-				run_command(self.cmd)
+			run_command(self.cmd)
 		else:
 			return execute_method(self)
 	return execute


### PR DESCRIPTION
Hi!

The reconfiguration shouldn't invalidate the user's build options. For example, if the project has more than one task generator and autoconfig is set as 'clobber', then a reconfiguration triggered when the command `waf --targets=foo` is issued would make the build command post all taskgens instead of only the one named as 'foo'. This PR intends to fix that.

Best regards,
Gustavo Sousa