### PR TITLE
Manage case in unit_test running when LD_LIBRARY_PATH is not already defined in the environment

### DIFF
--- a/waflib/Tools/waf_unit_test.py
+++ b/waflib/Tools/waf_unit_test.py
@@ -76,7 +76,7 @@ def make_test(self):
 	if not hasattr(self, 'ut_env'):
 		self.ut_env = dct = dict(os.environ)
 		def add_path(var):
-			dct[var] = self.ut_paths + dct[var]
+			dct[var] = self.ut_paths + dct.get(var,'')
 		if Utils.is_win32:
 			add_path('PATH')
 		elif Utils.unversioned_sys_platform() == 'darwin':


### PR DESCRIPTION

When running a unit test if LD_LIBRARY_PATH is undefined in the local environment the execution will end with an error:

```
  File "/home/fede/waf/wafm/waf-master/.waf-1.9.0-6564ab2e0480b52e07ca5175f6e3287e/waflib/TaskGen.py", line 111, in post
    v()
  File "/home/fede/waf/wafm/waf-master/.waf-1.9.0-6564ab2e0480b52e07ca5175f6e3287e/waflib/Tools/waf_unit_test.py", line 49, in make_test
    add_path('LD_LIBRARY_PATH')
  File "/home/fede/waf/wafm/waf-master/.waf-1.9.0-6564ab2e0480b52e07ca5175f6e3287e/waflib/Tools/waf_unit_test.py", line 42, in add_path
    dct[var]=self.ut_paths+dct[var]
KeyError: 'LD_LIBRARY_PATH'
```

Just handle this by putting an empty string as default