### PR TITLE
qt5: uic generation task missing path to target, name conflict possible

### DIFF
--- a/waflib/Tools/qt5.py
+++ b/waflib/Tools/qt5.py
@@ -299,7 +299,7 @@ def create_rcc_task(self, node):
 def create_uic_task(self, node):
 	"hook for uic tasks"
 	uictask = self.create_task('ui5', node)
-	uictask.outputs = [self.path.find_or_declare(self.env['ui_PATTERN'] % node.name[:-3])]
+	uictask.outputs = [node.parent.find_or_declare(self.env['ui_PATTERN'] % node.name[:-3])]
 
 @extension('.ts')
 def add_lang(self, node):


### PR DESCRIPTION
When a header file is generated from .ui files the target generated (with the pattern ui_XXXX.h) is missing the full path, leading to possible name clashes and in general to a pollution of the build directory structure which may require additional unwanted includes to be added.

So for example

```
a/panel.ui
b/panel.ui
c/panel.ui
```
will all get generated as `build/ui_panel.h`, therefore leading to a name clash. Even if the name didn't collide one would have to always include "." in all three cases to make it work.

The little patch will preserve the directory structure leading to generation:

```
build/a/ui_panel.h
build/b/ui_panel.h
build/c/ui_panel.h
```

