### PR TITLE
Fix error when adding new items to SAVED_ATTRS

### DIFF
--- a/waflib/Build.py
+++ b/waflib/Build.py
@@ -316,7 +316,7 @@ class BuildContext(Context.Context):
 					Logs.debug('build: Could not pickle the build cache %s: %r', dbfn, e)
 				else:
 					for x in SAVED_ATTRS:
-						setattr(self, x, data[x])
+						setattr(self, x, data.get(x, {}))
 			finally:
 				Node.pickle_lock.release()
 


### PR DESCRIPTION
If something was added to SAVED_ATTRS, the next build command failed because
the saved dictionary in the pickle file didn't have that new key.