### PR TITLE
If compiler_cxx was not configured before qt5 then qt5 will try to build applications with an empty compiler which gives very strange errors in the config log

### DIFF
--- a/waflib/Tools/qt5.py
+++ b/waflib/Tools/qt5.py
@@ -497,6 +497,9 @@ def configure(self):
 	if not has_xml:
 		Logs.error('No xml.sax support was found, rcc dependencies will be incomplete!')
 
+	if 'COMPILER_CXX' not in self.env:
+		self.fatal('No CXX compiler defined: did you forget to configure compiler_cxx first?')
+
 	# Qt5 may be compiled with '-reduce-relocations' which requires dependent programs to have -fPIE or -fPIC?
 	frag = '#include <QApplication>\nint main(int argc, char **argv) {return 0;}\n'
 	uses = 'QT5CORE QT5WIDGETS QT5GUI'


### PR DESCRIPTION
Just check if the compiler is not there and remember the user that compiler_cxx should be configured before qt5.
The module example correctly says compiler_cxx has to be first, but in case of error maybe an explicative error message helps.

config.log example when compiler_cxx not configured before:

```
----------------------------------------------------
See if Qt files compile with ['-std=c++11', '-fPIC']
==>
#include <QApplication>
int main(int argc, char **argv) {return 0;}

<==
[1/1] Compiling ESC[32mbuild/.conf_check_9d4e23b9c7e09c281cf99cae0e7ad262/test.cppESC[0m

['-std=c++11', '-fPIC', '../test.cpp', '/home/fede/waf/twomod/build/.conf_check_9d4e23b9c7e09c281cf99cae0e7ad262/testbuild/test.cpp.1.o']

...
WafError: Execution failure: ['-std=c++11', '-fPIC', '../test.cpp', '/home/fede/waf/twomod/build/.conf_check_9d4e23b9c7e09c281cf99cae0e7ad262/testbuild/test.cpp.1.o']
Traceback (most recent call last):
  File "<string>", line 33, in run
  File "/usr/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1327, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory

```
