### PR TITLE
Less verbose output when a task failed if not running with -v

### DIFF
--- a/waflib/Task.py
+++ b/waflib/Task.py
@@ -410,7 +410,10 @@ class TaskBase(evil):
 
 		:rtype: string
 		"""
-		msg = getattr(self, 'last_cmd', '')
+		if Logs.verbose:
+			msg = ': %r\n%r' % (self, getattr(self, 'last_cmd', ''))
+		else:
+			msg = ' (run with -v to display more information)'
 		name = getattr(self.generator, 'name', '')
 		if getattr(self, "err_msg", None):
 			return self.err_msg
@@ -418,11 +421,11 @@ class TaskBase(evil):
 			return 'task in %r was not executed for some reason: %r' % (name, self)
 		elif self.hasrun == CRASHED:
 			try:
-				return ' -> task in %r failed (exit status %r): %r\n%r' % (name, self.err_code, self, msg)
+				return ' -> task in %r failed with exit status %r%s' % (name, self.err_code, msg)
 			except AttributeError:
-				return ' -> task in %r failed: %r\n%r' % (name, self, msg)
+				return ' -> task in %r failed%s' % (name, msg)
 		elif self.hasrun == MISSING:
-			return ' -> missing files in %r: %r\n%r' % (name, self, msg)
+			return ' -> missing files in %r%s' % (name, msg)
 		else:
 			return 'invalid status for task in %r: %r' % (name, self.hasrun)
 


### PR DESCRIPTION
Currently waf prints the task and the command when a build task failed. Especially with linker errors this results in a lot of output. For example when linking hundreds of object files `str(self)` lists all of them as inputs and `last_cmd` lists all of them again as they are passed to the linker.

This PR changes the behavior so that the verbose output is only shown when running with at least `-v`.