### PR TITLE
Don't fail on output decoding errors

### DIFF
--- a/waflib/Context.py
+++ b/waflib/Context.py
@@ -116,6 +116,12 @@ class store_context(type):
 ctx = store_context('ctx', (object,), {})
 """Base class for all :py:class:`waflib.Context.Context` classes"""
 
+def decode(out):
+	try:
+		return out.decode(sys.stdout.encoding or 'iso8859-1', errors='replace')
+	except TypeError: # Python <= 2.6
+		return out.decode(sys.stdout.encoding or 'iso8859-1')
+
 class Context(ctx):
 	"""
 	Default context for waf commands, and base class for new command contexts.
@@ -355,14 +361,14 @@ class Context(ctx):
 
 		if out:
 			if not isinstance(out, str):
-				out = out.decode(sys.stdout.encoding or 'iso8859-1')
+				out = decode(out)
 			if self.logger:
 				self.logger.debug('out: %s', out)
 			else:
 				Logs.info(out, extra={'stream':sys.stdout, 'c1': ''})
 		if err:
 			if not isinstance(err, str):
-				err = err.decode(sys.stdout.encoding or 'iso8859-1')
+				err = decode(err)
 			if self.logger:
 				self.logger.error('err: %s' % err)
 			else:
@@ -440,9 +446,9 @@ class Context(ctx):
 			raise Errors.WafError('Execution failure: %s' % str(e), ex=e)
 
 		if not isinstance(out, str):
-			out = out.decode(sys.stdout.encoding or 'iso8859-1')
+			out = decode(out)
 		if not isinstance(err, str):
-			err = err.decode(sys.stdout.encoding or 'iso8859-1')
+			err = decode(err)
 
 		if out and quiet != STDOUT and quiet != BOTH:
 			self.to_log('out: %s' % out)


### PR DESCRIPTION
Sometimes my tasks have invalid characters in their output (for example a source file which is encoded in an encoding different from `sys.stdout.encoding` or a test program which has a bug). Currently waf fails with an exception without showing me the output at all.

This PR uses `errors='replace'` which will replace any decoding errors with ? characters, just as most terminals would do anyway. AFAIK it's only available since Python 2.7, that's why I've added the try/except.

I've tested this with Python 3.5 on Windows and on CentOS 6 with Python 2.6.