### PR TITLE
Allow using directories as waf tools

### DIFF
--- a/wscript
+++ b/wscript
@@ -232,11 +232,28 @@ def create_waf(self, *k, **kw):
 	if zipType not in zip_types:
 		zipType = zip_types[0]
 
-
+	directoryFiles = {}
 	files = []
 	add3rdparty = []
 	for x in Options.options.add3rdparty.split(','):
-		if os.path.isabs(x):
+		if os.path.isdir(x):
+			# Create mapping over files in directory to location in
+			# waflib.extras
+			root_dir = os.path.basename(os.path.normpath(x))
+			
+			for root, _, file_list in os.walk(x):
+				for file_name in file_list:
+					relative_dir = os.path.relpath(root, x)
+					relative_file = os.path.normpath(
+						os.path.join(root_dir, relative_dir, file_name))
+						
+					file_from = os.path.abspath(os.path.join(root, file_name))
+					file_to = relative_file
+					
+					directoryFiles[file_from] = file_to
+					files.append(file_from)
+			
+		elif os.path.isabs(x):
 			files.append(x)
 		else:
 			add3rdparty.append(x + '.py')
@@ -283,7 +300,9 @@ def create_waf(self, *k, **kw):
 		(code, size, cnt) = sfilter(x)
 		tarinfo.size = size
 
-		if os.path.isabs(x):
+		if x in directoryFiles:
+			tarinfo.name = 'waflib/extras/' + directoryFiles[x]
+		elif os.path.isabs(x):
 			tarinfo.name = 'waflib/extras/' + os.path.split(x)[1]
 
 		print('   adding %s as %s' % (x, tarinfo.name))
@@ -408,4 +427,3 @@ def build(bld):
 class Dist(Scripting.Dist):
 	def get_excl(self):
 		return super(self.__class__, self).get_excl() + ' **/waflib.zip'
-


### PR DESCRIPTION
Sometimes it is useful to be able to add a module to waf as a tool.

Using this patch one can use `./waf-light configure build --tools /tmp/mytool`

This will add the files under /tmp/mytool under /waflib/extras/mytool. Such
that they can be imported in a wscript as `from waflib.extras import mytool`.