### PR TITLE
qt5: pass cppcheck_skip=True flag when doing configuration test build otherwise build will fail if cppcheck extra loaded after qt5 (or will execute cppcheck during config phase which is useless anyway)

### DIFF
--- a/waflib/Tools/qt5.py
+++ b/waflib/Tools/qt5.py
@@ -508,7 +508,7 @@ def configure(self):
 		if flag:
 			msg += 'with %s' % flag
 		try:
-			self.check(features='qt5 cxx', use=uses, uselib_store='qt5', cxxflags=flag, fragment=frag, msg=msg)
+			self.check(features='qt5 cxx', use=uses, uselib_store='qt5', cxxflags=flag, fragment=frag, msg=msg, cppcheck_skip=True)
 		except self.errors.ConfigurationError:
 			pass
 		else:


### PR DESCRIPTION

If both qt5 and cppcheck are used at the same time we have two cases:

1) If qt5 is loaded first then the qt5 compilation test code executed during "waf configure" will fail since cppcheck will be called, but this is not yet configured, doesn't have an executable name set and will fail:

`WafError: Execution failure: ['--inconclusive', '--report-progress', '--verbose', '--xml', '--xml-version=2', '--max-configs=[]', '--language=c++', '--std=[]', '--enable=[]', '/home/fede/waf/qt5test/build/.conf_check_ab611691f58b1fe96719f28f2ae060c2/test.cpp', '-I/usr/include/qt5/QtCore', '-I/usr/include/qt5', '-I/usr/include/qt5/QtWidgets', '-I/usr/include/qt5/QtGui']
`
2) If cppcheck is loaded first configure will work but additional cppchecks will be done on it which I don't think makes much sense (for speed, logic, possible failure of future tests and pollution with xml files).

In my PR I propose to just pass always the cppcheck_skip flag which will just disable cppchecking on the file. If no cppcheck is used this flag will still be there but it is harmless. I don't know if it is worth checking if the other extra is loaded and then passing it, would just overcomplicate it.



