### PR TITLE
Replace optparse with argparse

### DIFF
--- a/waflib/Options.py
+++ b/waflib/Options.py
@@ -49,7 +49,7 @@ class opt_parser(argparse.ArgumentParser):
 		argparse.ArgumentParser.__init__(self, conflict_handler="resolve",
 			version='waf %s (%s)' % (Context.WAFVERSION, Context.WAFREVISION),
 			usage=usage)
-		#self.formatter.width = Logs.get_term_cols()
+
 		self.ctx = ctx
 
 	def print_usage(self, file=None):


### PR DESCRIPTION
The purpose of this pull-request is to move the option parser functionality from `optparse` to `argparse`.

The primary motivation for this is that we have built a recursive dependency resolution tool for waf. 

Using this we do not a-head of time know exactly what options will be added when resolving a dependency. However, a developer may already know this in advance. `optparse` will complain if it sees an option that it does not know, whereas `argparse` is a bit for flexible.

What do you think? Is this worthwhile pursuing? 

All the best,
Morten
