### PR TITLE
Accept functools.partial() as a task rule #1862

### DIFF
--- a/waflib/Task.py
+++ b/waflib/Task.py
@@ -7,6 +7,7 @@ Tasks represent atomic operations such as processes.
 """
 
 import os, re, sys, tempfile
+from functools import partial
 from waflib import Utils, Logs, Errors
 
 # task states
@@ -291,7 +292,13 @@ class TaskBase(evil):
 			pass
 
 		try:
-			ret = self.run()
+			if isinstance(self.run, partial):
+				# Python documentation says: "partial objects defined in classes
+				# behave like static methods and do not transform into bound
+				# methods during instance attribute look-up."
+				ret = self.run(self)
+			else:
+				ret = self.run()
 		except Exception:
 			self.err_msg = Utils.ex_stack()
 			self.hasrun = EXCEPTION

--- a/waflib/Task.py
+++ b/waflib/Task.py
@@ -7,7 +7,6 @@ Tasks represent atomic operations such as processes.
 """
 
 import os, re, sys, tempfile
-from functools import partial
 from waflib import Utils, Logs, Errors
 
 # task states
@@ -292,13 +291,7 @@ class TaskBase(evil):
 			pass
 
 		try:
-			if isinstance(self.run, partial):
-				# Python documentation says: "partial objects defined in classes
-				# behave like static methods and do not transform into bound
-				# methods during instance attribute look-up."
-				ret = self.run(self)
-			else:
-				ret = self.run()
+			ret = self.run()
 		except Exception:
 			self.err_msg = Utils.ex_stack()
 			self.hasrun = EXCEPTION

--- a/waflib/TaskGen.py
+++ b/waflib/TaskGen.py
@@ -11,6 +11,7 @@ is deferred. To achieve this, various methods are called from the method "apply"
 """
 
 import copy, re, os
+from functools import partial
 from waflib import Task, Utils, Logs, Errors, ConfigSet, Node
 
 feats = Utils.defaultdict(set)
@@ -633,6 +634,13 @@ def process_rule(self):
 
 	if getattr(self, 'cwd', None):
 		tsk.cwd = self.cwd
+
+	if type(tsk.run) is partial:
+		# Python documentation says: "partial objects defined in classes
+		# behave like static methods and do not transform into bound
+		# methods during instance attribute look-up."
+		tsk.run = partial(tsk.run, tsk)
+
 
 @feature('seq')
 def sequence_order(self):

--- a/waflib/Utils.py
+++ b/waflib/Utils.py
@@ -10,6 +10,8 @@ through Python versions 2.5 to 3.X and across different platforms (win32, linux,
 """
 
 import os, sys, errno, traceback, inspect, re, datetime, platform, base64, signal
+import functools
+
 try:
 	import cPickle
 except ImportError:
@@ -604,6 +606,10 @@ def h_cmd(ins):
 	elif isinstance(ins, list) or isinstance(ins, tuple):
 		# or a list of functions/strings
 		ret = str([h_cmd(x) for x in ins])
+	elif isinstance(ins, functools.partial):
+		ret = str([h_list(ins.args),
+		           h_list(tuple(ins.keywords.items())),
+		           h_fun(ins.func)])
 	else:
 		# or just a python function
 		ret = str(h_fun(ins))


### PR DESCRIPTION
Besides hashing `functools.partial` objects, I needed to tweak `process_rule` to take it into account.  The reason is that normally a function defined inside a class becomes a bound method automatically when accessed through an instance, but not so for functools.partial.  Docs say:
>  partial objects defined in classes behave like static methods and do not transform into bound methods during instance attribute look-up.