### PR TITLE
Ignore errors in shutils.rmtree

### DIFF
--- a/waflib/Configure.py
+++ b/waflib/Configure.py
@@ -594,7 +594,8 @@ def run_build(self, *k, **kw):
 			proj['cache_run_build'] = ret
 			proj.store(os.path.join(dir, 'cache_run_build'))
 		else:
-			shutil.rmtree(dir)
+			# Ignore errors. Windows will sometimes not allow the directory to be deleted
+			shutil.rmtree(dir, ignore_errors=True)
 	return ret
 
 @conf


### PR DESCRIPTION
Causes shutils.rmtree() to ignore errors when attempting to clean up the
temporary configuration directory. This is necessary on Windows when
executing a program during Configuration.check() because it doesn't
appear to allow the parent directory to be removed if it recently had a
running executable file in it.

Without this change, this trivial wscript fails on Windows platforms:

    def options(opt):
        opt.load('compiler_c')

    def configure(cfg):
        cfg.load('compiler_c')
        cfg.check(execute=True, msg='Executing program')