### PR TITLE
correct static lib extension for emscripten

### DIFF
--- a/waflib/extras/c_emscripten.py
+++ b/waflib/extras/c_emscripten.py
@@ -76,9 +76,8 @@ def configure(conf):
 	conf.env.ARFLAGS = ['rcs']
 	conf.env.cshlib_PATTERN = '%s.js'
 	conf.env.cxxshlib_PATTERN = '%s.js'
-	conf.env.cstlib_PATTERN = '%s.bc'
-	conf.env.cxxstlib_PATTERN = '%s.bc'
+	conf.env.cstlib_PATTERN = '%s.a'
+	conf.env.cxxstlib_PATTERN = '%s.a'
 	conf.env.cprogram_PATTERN = '%s.html'
 	conf.env.cxxprogram_PATTERN = '%s.html'
 	conf.env.append_value('LINKFLAGS',['-Wl,--enable-auto-import'])
-


### PR DESCRIPTION
When linking with static libraries emscripten would consider .a files not .bc