### PR TITLE
Fixed '-o' flag for emscripten/clang

### DIFF
--- a/waflib/extras/c_emscripten.py
+++ b/waflib/extras/c_emscripten.py
@@ -61,6 +61,7 @@ def find_emscripten(conf):
 	cxx = conf.find_program(['em++'], var='CXX')
 	conf.env.CXX = cxx
 	conf.env.CXX_NAME = 'emscripten'
+
 	conf.find_program(['emar'], var='AR')
 
 def configure(conf):
@@ -80,4 +81,6 @@ def configure(conf):
 	conf.env.cxxstlib_PATTERN = '%s.a'
 	conf.env.cprogram_PATTERN = '%s.html'
 	conf.env.cxxprogram_PATTERN = '%s.html'
+	conf.env.CXX_TGT_F           = ['-c', '-o', '']
+	conf.env.CC_TGT_F            = ['-c', '-o', '']
 	conf.env.append_value('LINKFLAGS',['-Wl,--enable-auto-import'])

--- a/waflib/extras/c_emscripten.py
+++ b/waflib/extras/c_emscripten.py
@@ -76,9 +76,8 @@ def configure(conf):
 	conf.env.ARFLAGS = ['rcs']
 	conf.env.cshlib_PATTERN = '%s.js'
 	conf.env.cxxshlib_PATTERN = '%s.js'
-	conf.env.cstlib_PATTERN = '%s.bc'
-	conf.env.cxxstlib_PATTERN = '%s.bc'
+	conf.env.cstlib_PATTERN = '%s.a'
+	conf.env.cxxstlib_PATTERN = '%s.a'
 	conf.env.cprogram_PATTERN = '%s.html'
 	conf.env.cxxprogram_PATTERN = '%s.html'
 	conf.env.append_value('LINKFLAGS',['-Wl,--enable-auto-import'])
-

--- a/waflib/extras/c_emscripten.py
+++ b/waflib/extras/c_emscripten.py
@@ -61,7 +61,6 @@ def find_emscripten(conf):
 	cxx = conf.find_program(['em++'], var='CXX')
 	conf.env.CXX = cxx
 	conf.env.CXX_NAME = 'emscripten'
-
 	conf.find_program(['emar'], var='AR')
 
 def configure(conf):


### PR DESCRIPTION
Emscripten requires space after '-o' flag. This fixes it.