### PR TITLE
Respect PKG_CONFIG environment variable.

### DIFF
--- a/waflib/Tools/c_config.py
+++ b/waflib/Tools/c_config.py
@@ -234,7 +234,10 @@ def validate_cfg(self, kw):
 	"""
 	if not 'path' in kw:
 		if not self.env.PKGCONFIG:
-			self.find_program('pkg-config', var='PKGCONFIG')
+			if os.environ.get('PKG_CONFIG'):
+				self.env.PKGCONFIG = os.environ.get('PKG_CONFIG')
+			else:
+				self.find_program('pkg-config', var='PKGCONFIG')
 		kw['path'] = self.env.PKGCONFIG
 
 	# pkg-config version


### PR DESCRIPTION
Currently will always search the build machines PATH and does
not allow the path to pkg-config to be pointed to an alternate
location eg. SYSROOT of target.

This matches behavior of autoconf.