### PR TITLE
Allow numbers for Java compat attribute

### DIFF
--- a/waflib/Tools/javaw.py
+++ b/waflib/Tools/javaw.py
@@ -95,7 +95,7 @@ def apply_java(self):
 	tsk.srcdir = tmp
 
 	if getattr(self, 'compat', None):
-		tsk.env.append_value('JAVACFLAGS', ['-source', self.compat])
+		tsk.env.append_value('JAVACFLAGS', ['-source', str(self.compat)])
 
 	if hasattr(self, 'sourcepath'):
 		fold = [isinstance(x, Node.Node) and x or self.path.find_dir(x) for x in self.to_list(self.sourcepath)]


### PR DESCRIPTION
If the compat attribute was an integer the build would throw an exception due to it not being iterable.  Convert it to a string to be more flexible.