### PR TITLE
Improve error message about version mismatch

### DIFF
--- a/waflib/Build.py
+++ b/waflib/Build.py
@@ -296,7 +296,8 @@ class BuildContext(Context.Context):
 			pass
 		else:
 			if env.version < Context.HEXVERSION:
-				raise Errors.WafError('Version mismatch! reconfigure the project')
+				raise Errors.WafError('Project was configured with a different version of Waf.\n'
+				                      'Please reconfigure it (this will discard old build information).')
 			for t in env.tools:
 				self.setup(**t)
 


### PR DESCRIPTION
See #1870.

I made the message a little simpler, so that it doesn't include `waf configure`.

Sorry that I didn't reply to your question in my previous PR #1893, I didn't find the time last week.