### PR TITLE
c_osx: Fix install task for mac_files

### DIFF
--- a/waflib/Tools/c_osx.py
+++ b/waflib/Tools/c_osx.py
@@ -102,7 +102,7 @@ def create_task_macapp(self):
 			for node in self.to_nodes(self.mac_files):
 				relpath = node.path_from(mac_files_root or node.parent)
 				self.create_task('macapp', node, res_dir.make_node(relpath))
-				self.add_install_as(install_to=os.path.join(inst_to, relpath), install_source=node)
+				self.add_install_as(install_to=os.path.join(inst_to, relpath), install_from=node)
 
 		if getattr(self.bld, 'is_install', None):
 			# disable regular binary installation


### PR DESCRIPTION
Without the fix, the following error is being generated:

```
✔  22:14 ~/Devel/ndn/ChronoShare [ blabla L | ✚ 2 ] $ ./waf install
Waf: Entering directory `/Users/cawka/Devel/ndn/ChronoShare/build'
Waf: Leaving directory `/Users/cawka/Devel/ndn/ChronoShare/build'
Traceback (most recent call last):
  File "/Users/cawka/Devel/ndn/ChronoShare/.waf-1.9.8-6bd4f1773040d5281015a793f518c0ed/waflib/Scripting.py", line 120, in waf_entry_point
    run_commands()
  File "/Users/cawka/Devel/ndn/ChronoShare/.waf-1.9.8-6bd4f1773040d5281015a793f518c0ed/waflib/Scripting.py", line 181, in run_commands
    ctx=run_command(cmd_name)
  File "/Users/cawka/Devel/ndn/ChronoShare/.waf-1.9.8-6bd4f1773040d5281015a793f518c0ed/waflib/Scripting.py", line 172, in run_command
    ctx.execute()
  File "/Users/cawka/Devel/ndn/ChronoShare/.waf-1.9.8-6bd4f1773040d5281015a793f518c0ed/waflib/Scripting.py", line 362, in execute
    return execute_method(self)
  File "/Users/cawka/Devel/ndn/ChronoShare/.waf-1.9.8-6bd4f1773040d5281015a793f518c0ed/waflib/Build.py", line 99, in execute
    self.execute_build()
  File "/Users/cawka/Devel/ndn/ChronoShare/.waf-1.9.8-6bd4f1773040d5281015a793f518c0ed/waflib/Build.py", line 106, in execute_build
    self.compile()
  File "/Users/cawka/Devel/ndn/ChronoShare/.waf-1.9.8-6bd4f1773040d5281015a793f518c0ed/waflib/Build.py", line 173, in compile
    self.producer.start()
  File "/Users/cawka/Devel/ndn/ChronoShare/.waf-1.9.8-6bd4f1773040d5281015a793f518c0ed/waflib/Runner.py", line 148, in start
    self.refill_task_list()
  File "/Users/cawka/Devel/ndn/ChronoShare/.waf-1.9.8-6bd4f1773040d5281015a793f518c0ed/waflib/Runner.py", line 99, in refill_task_list
    self.outstanding.extend(self.biter.next())
  File "/Users/cawka/Devel/ndn/ChronoShare/.waf-1.9.8-6bd4f1773040d5281015a793f518c0ed/waflib/Build.py", line 409, in get_build_iterator
    self.post_group()
  File "/Users/cawka/Devel/ndn/ChronoShare/.waf-1.9.8-6bd4f1773040d5281015a793f518c0ed/waflib/Build.py", line 388, in post_group
    f()
  File "/Users/cawka/Devel/ndn/ChronoShare/.waf-1.9.8-6bd4f1773040d5281015a793f518c0ed/waflib/TaskGen.py", line 117, in post
    v()
  File "/Users/cawka/Devel/ndn/ChronoShare/.waf-1.9.8-6bd4f1773040d5281015a793f518c0ed/waflib/Tools/c_osx.py", line 70, in create_task_macapp
    self.add_install_as(install_to=os.path.join(inst_to,relpath),install_source=node,install_from="")
  File "/Users/cawka/Devel/ndn/ChronoShare/.waf-1.9.8-6bd4f1773040d5281015a793f518c0ed/waflib/Build.py", line 481, in add_install_as
    return self.add_install_task(**kw)
  File "/Users/cawka/Devel/ndn/ChronoShare/.waf-1.9.8-6bd4f1773040d5281015a793f518c0ed/waflib/Build.py", line 470, in add_install_task
    tsk.init_files()
  File "/Users/cawka/Devel/ndn/ChronoShare/.waf-1.9.8-6bd4f1773040d5281015a793f518c0ed/waflib/Build.py", line 498, in init_files
    assert len(inputs)==1
AssertionError
```