### PR TITLE
Use platform-independent path separators when adding tool directories

### DIFF
--- a/wscript
+++ b/wscript
@@ -258,7 +258,10 @@ def create_waf(self, *k, **kw):
 				file_from = f.abspath()
 				file_to = os.path.join(x_dir.name, f.path_from(x_dir))
 
-				directory_files[file_from] = file_to
+				# If this is executed on Windows, then file_to will contain
+				# '\' path separators. These should be changed to '/', otherwise
+				# the added tools will not be accessible on Unix systems.
+				directory_files[file_from] = file_to.replace('\\', '/')
 				files.append(file_from)
 
 		elif os.path.isabs(x):


### PR DESCRIPTION
I fixed an issue regarding the tool directories feature that was added by my friend @mortenvp here:
https://github.com/waf-project/waf/pull/1829

I tried to build a waf binary on Windows with some tool directories added, and the resulting binary worked fine on Windows, but when I copied it to a Unix system it failed to find the embedded tools.
It turns out that we stored a Windows-style path in `directory_files` that contained `\` path separators, and these paths were used in `tarinfo.name`. So when Python extracted the archive on a Unix system, the stored `\` path separators created an obvious problem.

The problem is fixed below by always using the `/` path separator. I also added a comment to explain the problem.