### PR TITLE
Support CLICOLOR(_FORCE) to control colored output

### DIFF
--- a/waflib/Options.py
+++ b/waflib/Options.py
@@ -108,6 +108,10 @@ class OptionsContext(Context.Context):
 		jobs = self.jobs()
 		p = self.add_option
 		color = os.environ.get('NOCOLOR', '') and 'no' or 'auto'
+		if os.environ.get('CLICOLOR', '') == '0':
+			color = 'no'
+		elif os.environ.get('CLICOLOR_FORCE', '') == '1':
+			color = 'yes'
 		p('-c', '--color',    dest='colors',  default=color, action='store', help='whether to use colors (yes/no/auto) [default: auto]', choices=('yes', 'no', 'auto'))
 		p('-j', '--jobs',     dest='jobs',    default=jobs,  type='int', help='amount of parallel jobs (%r)' % jobs)
 		p('-k', '--keep',     dest='keep',    default=0,     action='count', help='continue despite errors (-kk to try harder)')


### PR DESCRIPTION
Currently the colored output of Waf can be disabled by the environment variable `NOCOLOR`. Especially when running Waf inside a CI server (which logs the output), it is required to pass `--color=yes`. This gets tedious when you have multiple invocations, e. g.

```sh
./waf --color=yes configure
./waf --color=yes build
./waf --color=yes test
```

Therefore an environment variable to force colored output would be handy.

In order not to have too many different env variables one has to remember, I hope that `CLICOLOR` and `CLICOLOR_FORCE` can become some kind of standard, see https://bixense.com/clicolors/. CMake also supports `CLICOLOR_FORCE`, so I think it might be a good fit for Waf, too. Also the [ANSI plugin for Sublime](https://github.com/aziz/SublimeANSI) already encourages to set `CLICOLOR_FORCE=1`, so that Waf's output there would now be in color :)