### PR TITLE
Initial implementation

### DIFF
--- a/waflib/Context.py
+++ b/waflib/Context.py
@@ -9,6 +9,7 @@ Classes and functions enabling the command system
 import os, re, imp, sys
 from waflib import Utils, Errors, Logs
 import waflib.Node
+import waflib.Options
 
 # the following 3 constants are updated on each new release (do not touch)
 HEXVERSION=0x1090800
@@ -478,10 +479,18 @@ class Context(ctx):
 		"""
 		if self.logger:
 			self.logger.info('from %s: %s' % (self.path.abspath(), msg))
+		
 		try:
-			msg = '%s\n(complete log in %s)' % (msg, self.logger.handlers[0].baseFilename)
+			logfile = self.logger.handlers[0].baseFilename
 		except AttributeError:
-			pass
+			logfile = None
+			
+		if logfile and waflib.Options.options.print_failure_log:
+			with open(logfile, 'r') as f:
+				msg = '%s\nLog from (%s):\n%s\n' % (msg, logfile, f.read())
+		elif logfile:
+			msg = '%s\n(complete log in %s)' % (msg, logfile)
+			
 		raise self.errors.ConfigurationError(msg, ex=ex)
 
 	def to_log(self, msg):

--- a/waflib/Context.py
+++ b/waflib/Context.py
@@ -9,7 +9,6 @@ Classes and functions enabling the command system
 import os, re, imp, sys
 from waflib import Utils, Errors, Logs
 import waflib.Node
-import waflib.Options
 
 # the following 3 constants are updated on each new release (do not touch)
 HEXVERSION=0x1090800
@@ -485,9 +484,9 @@ class Context(ctx):
 		except AttributeError:
 			logfile = None
 			
-		if logfile and waflib.Options.options.print_failure_log:
+		if logfile and Logs.verbose:
 			with open(logfile, 'r') as f:
-				msg = '%s\nLog from (%s):\n%s\n' % (msg, logfile, f.read())
+				msg = 'Log from (%s):\n%s\n' % (logfile, f.read())
 		elif logfile:
 			msg = '%s\n(complete log in %s)' % (msg, logfile)
 			

--- a/waflib/Options.py
+++ b/waflib/Options.py
@@ -114,6 +114,7 @@ class OptionsContext(Context.Context):
 		p('-v', '--verbose',  dest='verbose', default=0,     action='count', help='verbosity level -v -vv or -vvv [default: 0]')
 		p('--zones',          dest='zones',   default='',    action='store', help='debugging zones (task_gen, deps, tasks, etc)')
 		p('--profile',        dest='profile', default='',    action='store_true', help=optparse.SUPPRESS_HELP)
+		p('--print-failure-log', dest='print_failure_log', default='', action='store_true', help='On failure print log file.')
 
 		gr = self.add_option_group('Configuration options')
 		self.option_groups['configure options'] = gr

--- a/waflib/Options.py
+++ b/waflib/Options.py
@@ -114,7 +114,6 @@ class OptionsContext(Context.Context):
 		p('-v', '--verbose',  dest='verbose', default=0,     action='count', help='verbosity level -v -vv or -vvv [default: 0]')
 		p('--zones',          dest='zones',   default='',    action='store', help='debugging zones (task_gen, deps, tasks, etc)')
 		p('--profile',        dest='profile', default='',    action='store_true', help=optparse.SUPPRESS_HELP)
-		p('--print-failure-log', dest='print_failure_log', default='', action='store_true', help='On failure print log file.')
 
 		gr = self.add_option_group('Configuration options')
 		self.option_groups['configure options'] = gr


### PR DESCRIPTION
Hi,
When running waf on a build-system sometimes things fail. When this happens one can go the the specific build machine and retrieve the log files for debugging. 

I was wondering whether adding support for a `--print-failure-log` or similar could be included into waf.

This would allow us to run `./waf configure --print-failure-log` and see directory in the output what went wrong.

Comments / feedback?
