### PR TITLE
eclipse: python integration improvements

### DIFF
--- a/waflib/extras/eclipse.py
+++ b/waflib/extras/eclipse.py
@@ -60,6 +60,14 @@ class eclipse(Build.BuildContext):
 				if not isinstance(tg, TaskGen.task_gen):
 					continue
 
+				# Add local Python modules paths to configuration so object resolving will work in IDE
+				if 'py' in tg.features:
+					pypath = tg.path.relpath()
+					py_installfrom = getattr(tg, 'install_from', None)
+					if py_installfrom:
+						pypath += os.sep + py_installfrom
+					pythonpath.append(pypath)
+
 				tg.post()
 				if not getattr(tg, 'link_task', None):
 					continue

--- a/waflib/extras/eclipse.py
+++ b/waflib/extras/eclipse.py
@@ -278,7 +278,7 @@ class eclipse(Build.BuildContext):
 			prop = self.add(doc, pydevproject, 'pydev_pathproperty',
 					{'name':'org.python.pydev.PROJECT_SOURCE_PATH'})
 			for i in user_path:
-				self.add(doc, prop, 'path', '/'+appname+'/'+i)
+				self.add(doc, prop, 'path', '/${PROJECT_DIR_NAME}/'+i)
 
 		doc.appendChild(pydevproject)
 		return doc


### PR DESCRIPTION

Tried to improve the Eclipse integration for Python so using pydev:
-) use standard variable PROJECT_DIR_NAME to make it more standard/portable
-) generate paths to python modules configured in wscripts so objects are then correctly found and resolved in the IDE without any additional manual configuration needed

