### PR TITLE
cpplint: fix Python 2 import name collision using `absolute_import`

### DIFF
--- a/waflib/extras/cpplint.py
+++ b/waflib/extras/cpplint.py
@@ -35,6 +35,7 @@ When using this tool, the wscript will look like:
         bld(features='cpplint', source=bld.path.ant_glob('**/*.hpp'))
 '''
 
+from __future__ import absolute_import
 import sys, re
 import logging
 import threading


### PR DESCRIPTION
Fixes #1960 