### PR TITLE
Preserve modification time for is_copy=True

### DIFF
--- a/waflib/TaskGen.py
+++ b/waflib/TaskGen.py
@@ -718,6 +718,8 @@ class subst_pc(Task.Task):
 		if getattr(self.generator, 'is_copy', None):
 			for i, x in enumerate(self.outputs):
 				x.write(self.inputs[i].read('rb'), 'wb')
+				stat = os.stat(self.inputs[i].abspath()) # Preserve mtime of the copy
+				os.utime(self.outputs[i].abspath(), (stat.st_atime, stat.st_mtime))
 			self.force_permissions()
 			return None
 


### PR DESCRIPTION
For

```python
bld(features='subst', is_copy=True, source='foo', target='bar')
```

`bar` will have the same last modified time as `foo`. Since the `is_copy` feature is mostly used to reconstruct some config files from the src folder to the build folder, having the correct mtime would be nice (also the file is in fact not modified because it has the same content).

Another method could be to use `shutil.copy2` which should even be available in Python 2.5: https://docs.python.org/release/2.5/lib/module-shutil.html That would also preserve the last access time though.