### PR TITLE
Fix decoding of vswhere's output #1965

### DIFF
--- a/waflib/Tools/msvc.py
+++ b/waflib/Tools/msvc.py
@@ -456,7 +456,7 @@ def gather_vswhere_versions(conf, versions):
 		Logs.debug('msvc: vswhere.exe failed %s', e)
 		return
 
-	arr = json.loads(txt)
+	arr = json.loads(txt.decode(sys.stdout.encoding))
 	arr.sort(key=lambda x: x['installationVersion'])
 	for entry in arr:
 		ver = entry['installationVersion']


### PR DESCRIPTION
This fix is working on my French Windows to solve the issue #1965. Can people review and test it, in particular with different locale settings? :)