### PR TITLE
Fix pdb installation in cs tool

### DIFF
--- a/waflib/Tools/cs.py
+++ b/waflib/Tools/cs.py
@@ -103,10 +103,10 @@ def debug_cs(self):
 	else:
 		out = node.change_ext('.pdb')
 	self.cs_task.outputs.append(out)
-	try:
-		self.install_task.source.append(out)
-	except AttributeError:
-		pass
+
+	if getattr(self, 'install_task', None):
+		self.pdb_install_task = self.add_install_files(
+			install_to=self.install_task.install_to, install_from=out)
 
 	if csdebug == 'pdbonly':
 		val = ['/debug+', '/debug:pdbonly']


### PR DESCRIPTION
The cs tool pdb installation doesn't appear to have been updated with the install_task changes.  This fixes it so the pdbs now get installed.

I encountered this issue in release 1.9.11