### PR TITLE
Allow overriding namespace of resx files.

### DIFF
--- a/waflib/extras/resx.py
+++ b/waflib/extras/resx.py
@@ -18,7 +18,7 @@ def resx_file(self, node):
 		self.bld.fatal('resx_file has no link task for use %r' % self)
 
 	# Given assembly 'Foo' and file 'Sub/Dir/File.resx', create 'Foo.Sub.Dir.File.resources'
-	assembly = os.path.splitext(self.gen)[0]
+	assembly = getattr(self, 'namespace', os.path.splitext(self.gen)[0])
 	res = os.path.splitext(node.path_from(self.path))[0].replace('/', '.').replace('\\', '.')
 	out = self.path.find_or_declare(assembly + '.' + res + '.resources')
 


### PR DESCRIPTION
Add new optional attribute `namespace` to the resx tool.

Sometimes, C# assemblies have compiled resources that don't match the assembly name.  The current resx tool assigns the resource namespace to the assembly name.

For example, if the assembly is `My.dll` and the resource is `Path/To/MyResource.resx`, the tool names the resource `My.Path.To.MyResource`.  This optional attribute allows you to change the behavior.  Specifying `namespace='Other'` would change the resource to `Other.Path.To.MyResource`.

A real world example is BouncyCastle.  The assembly is named `BouncyCastle.dll` but the assembly namespace is `Org.BouncyCastle`.