### PR TITLE
eclipse: query the compiler for standard include dirs and add them in eclipse search path, so standard includes can be found also with non standard compilers

### DIFF
--- a/waflib/extras/eclipse.py
+++ b/waflib/extras/eclipse.py
@@ -54,6 +54,16 @@ class eclipse(Build.BuildContext):
 		cpppath = self.env['CPPPATH']
 		javasrcpath = []
 		if sys.platform != 'win32':
+			try:
+				cccmd = self.env.get_flat('CC') or self.env.get_flat('CXX')
+				if cccmd:
+					gccout = self.cmd_and_log([cccmd, '-xc++', '-E', '-Wp,-v', '-'], output=Context.STDERR, quiet=Context.BOTH, input='\n'.encode()).split('\n')
+					STANDARD_INCLUDES[:] = []
+					for ipath in gccout:
+						if ipath.startswith(' /'):
+							STANDARD_INCLUDES.append(ipath[1:])
+			except Exception:
+				pass	# if cc command failed, fall back to hardcoded STANDARD_INCLUDES
 			cpppath += STANDARD_INCLUDES
 		Logs.warn('Generating Eclipse CDT project files')
 


### PR DESCRIPTION
if command doesn't succeed use hardcoded paths as before. tried with various gcc and llvm.