### PR TITLE
GCC: force space between -o and target file.

### DIFF
--- a/waflib/Tools/c_config.py
+++ b/waflib/Tools/c_config.py
@@ -1426,7 +1426,7 @@ def multicheck(self, *k, **kw):
 
 @conf
 def check_gcc_o_space(self, mode='c'):
-	if int(self.env.CC_VERSION[0]) > 4:
+	if (int(self.env.CC_VERSION[0]) > 4) or (int(self.env.CC_VERSION[0]) == 4 and int(self.env.CC_VERSION[1]) > 4):
 		# this is for old compilers
 		return
 	self.env.stash()


### PR DESCRIPTION
GCC passes unknown options directly to the linker. "-o$TARGETFILE" would be an example of such an option. If the linker does not support splitting up -o and the target file path by itself, linking will fail.
This happens on OS X, for instance.

Clang is not affected by this, since it does more work in recognizing options and splits up -o and $TARGETFILE before passing it to the linker.