### PR TITLE
Store the path the main process had been invoked from in Context.user_dir

### DIFF
--- a/waflib/Scripting.py
+++ b/waflib/Scripting.py
@@ -38,6 +38,10 @@ def waf_entry_point(current_directory, version, wafdir):
 		ctx.parse_args()
 		sys.exit(0)
 
+	# Store current directory before any chdir
+	Context.waf_dir = wafdir
+	Context.launch_dir = current_directory
+
 	if len(sys.argv) > 1:
 		# os.path.join handles absolute paths in sys.argv[1] accordingly (it discards the previous ones)
 		# if sys.argv[1] is not an absolute path, then it is relative to the current working directory
@@ -49,9 +53,6 @@ def waf_entry_point(current_directory, version, wafdir):
 			# TODO abspath?
 			current_directory = os.path.normpath(os.path.dirname(potential_wscript))
 			sys.argv.pop(1)
-
-	Context.waf_dir = wafdir
-	Context.launch_dir = current_directory
 
 	# if 'configure' is in the commands, do not search any further
 	no_climb = os.environ.get('NOCLIMB')


### PR DESCRIPTION
Waf does change directory as soon as it start executing the main wscript it has been invoked for, c.f. waflib.Scripting.py:waf_entry_point().

Because of this, it is not possible to support relative paths in module options. Those would be relative to the current working directory in which the main waf process is launched from (from the point of view of the user invoking it). 

By storing this path in Context.py, it is possible to write support relative paths in Options:

```
def options(opts):
    currOptsGroup = opts.add_option_group('Custom Flow Options')
    opts.option_groups['Custom_Flow_Options'] = currOptsGroup
    currOptsGroup.add_option('--input-file', action='store', default=None, help="Path to module input file", dest='input_file')

def configure(cnf):
    specifiedInputFile = cnf.options.input_file
    if not os.path.isabs(specifiedInputFile):
            specifiedInputFile = os.path.normpath(os.path.join(waflib.Context.user_dir, specifiedInputFile))

def build(dlb):
    ...

```
