### PR TITLE
Fix 'shell' attribute on waf_unit_test:exec_command() Popen call 

### DIFF
--- a/waflib/Tools/waf_unit_test.py
+++ b/waflib/Tools/waf_unit_test.py
@@ -178,7 +178,7 @@ class utest(Task.Task):
 				Logs.info('Test debug file written as %r' % script_file)
 
 		proc = Utils.subprocess.Popen(cmd, cwd=self.get_cwd().abspath(), env=self.get_test_env(),
-			stderr=Utils.subprocess.PIPE, stdout=Utils.subprocess.PIPE)
+			stderr=Utils.subprocess.PIPE, stdout=Utils.subprocess.PIPE, shell=isinstance(cmd,str))
 		(stdout, stderr) = proc.communicate()
 		self.waf_unit_test_results = tup = (self.inputs[0].abspath(), proc.returncode, stdout, stderr)
 		testlock.acquire()


### PR DESCRIPTION
`waf_unit_test.exec_command()` has a different behavior w.r.t. `Context:exec_command()` when trying to execute custom commands from a `run()` method defined in a waf_unit_test subclass. 

In `Context:exec_command()`, if the specified `cmd` is a string, the `shell` parameter to `Utils.subprocess.Popen` is set to `true`. 

This pull request proposes to uses the same approach for `waf_unit_test.exec_command()`