### PR TITLE
Default ignore Vim swap and Python Compiled files

### DIFF
--- a/waflib/Node.py
+++ b/waflib/Node.py
@@ -30,6 +30,8 @@ exclude_regs = '''
 **/.#*
 **/%*%
 **/._*
+**/*.swp
+**/*.pyc
 **/CVS
 **/CVS/**
 **/.cvsignore

--- a/waflib/Node.py
+++ b/waflib/Node.py
@@ -31,7 +31,6 @@ exclude_regs = '''
 **/%*%
 **/._*
 **/*.swp
-**/*.pyc
 **/CVS
 **/CVS/**
 **/.cvsignore


### PR DESCRIPTION
Python compiled  `*.pyc` and Vim `*.swp` are quite common, I think Waf can safely include them in default exclusion list.