### PR TITLE
Backport old gfortran compiler support.

### DIFF
--- a/waflib/Tools/fc_config.py
+++ b/waflib/Tools/fc_config.py
@@ -472,3 +472,17 @@ def detect_openmp(self):
 	else:
 		self.fatal('Could not find OpenMP')
 
+@conf
+def check_gfortran_o_space(self):
+	if self.env.FC_NAME != 'GFORTRAN' or int(self.env.FC_VERSION[0]) > 4:
+		# This is for old compilers and only for gfortran.
+		# No idea how other implementations handle this. Be safe and bail out.
+		return
+	self.env.stash()
+	self.env.FCLNK_TGT_F = ['-o', '']
+	try:
+		self.check_fc(msg='Checking if the -o link must be split from arguments', fragment=FC_FRAGMENT, features='fc fcshlib')
+	except self.errors.ConfigurationError:
+		self.env.revert()
+	else:
+		self.env.commit()

--- a/waflib/Tools/gfortran.py
+++ b/waflib/Tools/gfortran.py
@@ -90,3 +90,4 @@ def configure(conf):
 	conf.fc_add_flags()
 	conf.gfortran_flags()
 	conf.gfortran_modifier_platform()
+	conf.check_gfortran_o_space()


### PR DESCRIPTION
Same as for `gcc`/`g++` really, but only make usable for `gfortran`.