### PR TITLE
Fix for Intel Fortran Detection on Windows.

### DIFF
--- a/waflib/Tools/ifort.py
+++ b/waflib/Tools/ifort.py
@@ -76,7 +76,7 @@ def configure(conf):
 	Detects the Intel Fortran compilers
 	"""
 	if Utils.is_win32:
-		compiler, version, path, includes, libdirs, arch = conf.detect_ifort(True)
+		compiler, version, path, includes, libdirs, arch = conf.detect_ifort()
 		v = conf.env
 		v.DEST_CPU = arch
 		v.PATH = path


### PR DESCRIPTION
Seems like one input variable in a function call was forgotten to remove after c3af6e3fad646f0c349426fe8f982eca7f499648.