### PR TITLE
 javatest: extra to integrate java unit testing into standard waf_unit_test environment

### DIFF
--- a/playground/javatest/src/Nums.java
+++ b/playground/javatest/src/Nums.java
@@ -1,0 +1,17 @@
+public class Nums {
+	private int value = 0;
+
+	// Is bigger than 5
+	public boolean isBiggerThanFive() {
+		if (this.value > 5) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	// Set object value
+	public void setValue(int value) {
+		this.value = value;
+	}
+}

--- a/playground/javatest/test/TestNums.java
+++ b/playground/javatest/test/TestNums.java
@@ -1,0 +1,31 @@
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestNums {
+	Nums myNumObj = new Nums();
+
+	@Test
+	public void testTrue() {
+		myNumObj.setValue(10);
+
+		boolean isBigger = myNumObj.isBiggerThanFive();
+		Assert.assertEquals(true, isBigger, "10 should be bigger than 5");
+	}
+
+	@Test
+	public void testFalse() {
+		myNumObj.setValue(1);
+
+		boolean isBigger = myNumObj.isBiggerThanFive();
+		Assert.assertEquals(false, isBigger, "1 should be smaller than 5");
+	}
+
+	@Test
+	public void testBoundary() {
+		myNumObj.setValue(5);
+
+		boolean isBigger = myNumObj.isBiggerThanFive();
+		Assert.assertEquals(false, isBigger, "5 should not be bigger than 5");
+	}
+}
+

--- a/playground/javatest/test/testng.xml
+++ b/playground/javatest/test/testng.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Suite1">
+	<test name="test1">
+		<classes>
+			<class name="TestNums"/>
+		</classes>
+	</test>
+</suite>
+

--- a/playground/javatest/wscript
+++ b/playground/javatest/wscript
@@ -1,0 +1,53 @@
+#! /usr/bin/env python
+# encoding: utf-8
+# Federico Pellegrin, 2017 (fedepell)
+
+#
+# Simple script to demonstrate integration of Java Unit testing inside
+# standard waf_unit_test using either TestNG or JUnit
+#
+
+def test_results(bld):
+	"""
+	Custom post- function that prints out test results.
+	"""
+	lst = getattr(bld, 'utest_results', [])
+	if not lst:
+		return
+	for (f, code, out, err) in lst:
+		print(out.decode('utf-8'))
+		print(err.decode('utf-8'))
+
+
+def options(opt):
+	opt.load('java waf_unit_test javatest')
+
+def configure(conf):
+	conf.load('java javatest')
+
+def build(bld):
+	bld(features = 'javac',
+		name = 'mainprog',
+		srcdir     = 'src/', # folder containing the sources to compile
+		outdir     = 'src', # folder where to output the classes (in the build directory)
+		sourcepath = ['src'],
+		basedir    = 'src', # folder containing the classes and other files to package (must match outdir)
+	)
+
+
+	bld(features = 'javac javatest',
+		srcdir     = 'test/', # folder containing the sources to compile
+		outdir     = 'test', # folder where to output the classes (in the build directory)
+		sourcepath = ['test'],
+		classpath  = [ 'src' ], 
+		basedir    = 'test', # folder containing the classes and other files to package (must match outdir)
+		use = ['JAVATEST', 'mainprog'],
+		ut_str = 'java -cp ${CLASSPATH} ${JTRUNNER} ${SRC}',
+		jtest_source = bld.path.ant_glob('test/*.xml'),
+		# For JUnit do first JUnit configuration and no need to use jtest_source:
+		# ut_str = 'java -cp ${CLASSPATH} ${JTRUNNER} [TestClass]',
+	)
+
+
+	bld.add_post_fun(test_results)
+

--- a/waflib/extras/javatest.py
+++ b/waflib/extras/javatest.py
@@ -1,0 +1,118 @@
+#! /usr/bin/env python
+# encoding: utf-8
+# Federico Pellegrin, 2017 (fedepell)
+
+"""
+Provides Java Unit test support using :py:class:`waflib.Tools.waf_unit_test.utest`
+task via the **javatest** feature.
+
+This gives the possibility to run unit test and have them integrated into the
+standard waf unit test environment. It has been tested with TestNG and JUnit
+but should be easily expandable to other framework given the flexibility of
+ut_str provided by the standard waf unit test environment.
+
+Example usage:
+
+def options(opt):
+	opt.load('java waf_unit_test javatest')
+
+def configure(conf):
+	conf.load('java javatest')
+
+def build(bld):
+	
+	[ ... mainprog is built here ... ]
+
+	bld(features = 'javac javatest',
+		srcdir     = 'test/', 
+		outdir     = 'test', 
+		sourcepath = ['test'],
+		classpath  = [ 'src' ], 
+		basedir    = 'test', 
+		use = ['JAVATEST', 'mainprog'], # mainprog is the program being tested in src/
+		ut_str = 'java -cp ${CLASSPATH} ${JTRUNNER} ${SRC}',
+		jtest_source = bld.path.ant_glob('test/*.xml'),
+	)
+
+
+At command line the CLASSPATH where to find the testing environment and the
+test runner (default TestNG) that will then be seen in the environment as
+CLASSPATH_JAVATEST (then used for use) and JTRUNNER and can be used for
+dependencies and ut_str generation.
+
+Example configure for TestNG:
+	waf configure --jtpath=/tmp/testng-6.12.jar:/tmp/jcommander-1.71.jar --jtrunner=org.testng.TestNG
+		 or as default runner is TestNG:
+	waf configure --jtpath=/tmp/testng-6.12.jar:/tmp/jcommander-1.71.jar
+
+Example configure for JUnit:
+	waf configure --jtpath=/tmp/junit.jar --jtrunner=org.junit.runner.JUnitCore
+
+The runner class presence on the system is checked for at configuration stage.
+
+"""
+
+import os
+from waflib import Task, TaskGen, Options
+
+@TaskGen.feature('javatest')
+@TaskGen.after_method('apply_java', 'use_javac_files', 'set_classpath')
+def make_javatest(self):
+	"""
+	Creates a ``utest`` task with a populated environment for Java Unit test execution
+
+	"""
+	tsk = self.create_task('utest')
+	tsk.set_run_after(self.javac_task)
+
+	# Put test input files as waf_unit_test relies on that for some prints and log generation
+	# If jtest_source is there, this is specially useful for passing XML for TestNG
+	# that contain test specification, use that as inputs, otherwise test sources
+	if getattr(self, 'jtest_source', None):
+		tsk.inputs = self.to_nodes(self.jtest_source)
+	else:
+		if self.javac_task.srcdir[0].exists():
+			tsk.inputs = self.javac_task.srcdir[0].ant_glob('**/*.java', remove=False)
+
+	if getattr(self, 'ut_str', None):
+		self.ut_run, lst = Task.compile_fun(self.ut_str, shell=getattr(self, 'ut_shell', False))
+		tsk.vars = lst + tsk.vars
+
+	if getattr(self, 'ut_cwd', None):
+		if isinstance(self.ut_cwd, str):
+			# we want a Node instance
+			if os.path.isabs(self.ut_cwd):
+				self.ut_cwd = self.bld.root.make_node(self.ut_cwd)
+			else:
+				self.ut_cwd = self.path.make_node(self.ut_cwd)
+	else:
+		self.ut_cwd = self.bld.bldnode
+
+	# Get parent CLASSPATH and add output dir of test, we run from wscript dir
+	# We have to change it from list to the standard java -cp format (: separated)
+	tsk.env.CLASSPATH = ':'.join(self.env.CLASSPATH) + ':' + self.outdir.abspath()
+
+	if not self.ut_cwd.exists():
+		self.ut_cwd.mkdir()
+
+	if not hasattr(self, 'ut_env'):
+		self.ut_env = dict(os.environ)
+
+def configure(ctx):
+	cp = ctx.env.CLASSPATH or '.'
+	if getattr(Options.options, 'jtpath', None):
+		ctx.env.CLASSPATH_JAVATEST = getattr(Options.options, 'jtpath').split(':')
+		cp += ':' + getattr(Options.options, 'jtpath')
+
+	if getattr(Options.options, 'jtrunner', None):
+		ctx.env.JTRUNNER = getattr(Options.options, 'jtrunner')
+
+	if ctx.check_java_class(ctx.env.JTRUNNER, with_classpath=cp):
+		ctx.fatal('Could not run test class %r' % ctx.env.JTRUNNER)
+
+def options(opt):
+	opt.add_option('--jtpath', action='store', default='', dest='jtpath',
+		help='Path to jar(s) needed for javatest execution, colon separated, if not in the system CLASSPATH')
+	opt.add_option('--jtrunner', action='store', default='org.testng.TestNG', dest='jtrunner',
+		help='Class to run javatest test [default: org.testng.TestNG]')
+


### PR DESCRIPTION

Compared to the code in the java demo this integrates with the waf_unit_test so should be much easier to integrate with other languages unit tests (ie. pytest). It is also more versatile for different test environment and was testes with TestNG and JUnit.