### PR TITLE
qt5: resolve concurrency issues when files such as qm and qrc are used by multiple build tasks

### DIFF
--- a/waflib/Tools/qt5.py
+++ b/waflib/Tools/qt5.py
@@ -247,7 +247,7 @@ class XMLHandler(ContentHandler):
 @extension(*EXT_RCC)
 def create_rcc_task(self, node):
 	"Creates rcc and cxx tasks for ``.qrc`` files"
-	rcnode = node.change_ext('_rc.cpp')
+	rcnode = node.change_ext('_rc.%d.cpp' % (self.idx))
 	self.create_task('rcc', node, rcnode)
 	cpptask = self.create_task('cxx', rcnode, rcnode.change_ext('.o'))
 	try:
@@ -312,7 +312,7 @@ def apply_qt5(self):
 		for x in self.to_list(self.lang):
 			if isinstance(x, str):
 				x = self.path.find_resource(x + '.ts')
-			qmtasks.append(self.create_task('ts2qm', x, x.change_ext('.qm')))
+			qmtasks.append(self.create_task('ts2qm', x, x.change_ext('.%d.qm' % (self.idx))))
 
 		if getattr(self, 'update', None) and Options.options.trans_qt5:
 			cxxnodes = [a.inputs[0] for a in self.compiled_tasks] + [
@@ -324,7 +324,7 @@ def apply_qt5(self):
 			qmnodes = [x.outputs[0] for x in qmtasks]
 			rcnode = self.langname
 			if isinstance(rcnode, str):
-				rcnode = self.path.find_or_declare(rcnode + '.qrc')
+				rcnode = self.path.find_or_declare(rcnode + ('.%d.qrc' % (self.idx)))
 			t = self.create_task('qm2rcc', qmnodes, rcnode)
 			k = create_rcc_task(self, t.outputs[0])
 			self.link_task.inputs.append(k.outputs[0])


### PR DESCRIPTION
The patch solves concurrency issues when files are generated/converted on the fly by doing as ccroot or simillar, so generating filenames based on the self.idx. I tested with the demo (just copy multiple time same bld changing the target) and works fine.

There is just one more point that is not covered: the create_uic_task as the name there (ie. ui_xxx.h) is then explicitly set by the user in the source file, so this wouldn't work as it is not all internal bookkeeping.

Question: for the uic could we use a cache such as it is done for the moc files? (of course putting the same assumption that the transformation is identical). This could be the solution for the uic. 
In case should this caching be applied also to other stuff like qrc/qm? (although now they are covered for concurrency, it would still save time in builds)

Thanks!
