### PR TITLE
Set PYTHONPATH for pytest-tests depending on a pyext target

### DIFF
--- a/waflib/extras/pytest.py
+++ b/waflib/extras/pytest.py
@@ -136,11 +136,13 @@ def pytest_process_use(self):
 			if not isinstance(tg.link_task, ccroot.stlink_task):
 				extend_unique(self.pytest_dep_nodes, tg.link_task.outputs)
 				extend_unique(self.pytest_libpaths, tg.link_task.env.LIBPATH)
-				extend_unique(self.pytest_libpaths, [tg.link_task.outputs[0].get_bld().parent.abspath()])
+				bldpath = tg.link_task.outputs[0].get_bld().parent.abspath()
+				extend_unique(self.pytest_libpaths, [bldpath])
 
 				if 'pyext' in tg.features:
 					# If the taskgen is extending Python we also want to add it o the PYTHONPATH.
 					extend_unique(self.pytest_libpaths, tg.link_task.env.LIBPATH_PYEXT)
+					extend_unique(self.pytest_paths, [bldpath])
 
 
 @TaskGen.feature('pytest')


### PR DESCRIPTION
By not only including the appropriate build folder in `LD_LIBRARY_PATH`
but also in `PYTHONPATH`, the python extension module can be imported
by the test script.

For example the following will now work using `waf build` or `waf --alltests` (and failed to work before this change):

#### `wscript`:
```python
def build(bld):
    bld(
        target='some_extension',
        source='...',
        features='cxx cxxshlib pyext',
        use=['...'],
        install_path='${PREFIX}/lib',
    )

    bld(
        pytest_source='some_extension_test.py',
        features='pytest',
        use='some_extension',
        ut_str='${PYTEST} -q ${SRC}',
    )
```

#### `some_extension_test.py`:
```python
import some_extension
# ...
```