### PR TITLE
Fix recursion bug in TaskGen.__repr__ if task_gen field references self

### DIFF
--- a/waflib/TaskGen.py
+++ b/waflib/TaskGen.py
@@ -94,7 +94,7 @@ class task_gen(object):
 		"""Debugging helper"""
 		lst = []
 		for x in self.__dict__:
-			if x not in ('env', 'bld', 'compiled_tasks', 'tasks'):
+			if x not in ('env', 'bld', 'compiled_tasks', 'tasks') and self.__dict__[x] is not self:
 				lst.append("%s=%s" % (x, repr(getattr(self, x))))
 		return "bld(%s) in %s" % (", ".join(lst), self.path.abspath())
 


### PR DESCRIPTION
This is a merge request to fix a hard-to-debug issue that one of our users managed to trigger. It happens if a TaskGen is displayed in the console and the instance happens to somehow have a field that refers to itself. 

```
task = bld(...)
task.x = task
```

The result is an infinite recursion (until Python interp kills it). I realize that this is a very uncommon thing to do intentionally. But it turned out the user had a typo in their wscript that managed to produce this result.