### PR TITLE
Fix strangle issue with precompiled headers and shared libraries

### DIFF
--- a/waflib/extras/pch.py
+++ b/waflib/extras/pch.py
@@ -90,8 +90,8 @@ def apply_pch(self):
 
 	if getattr(self, 'name', None):
 		try:
-			task = self.bld.pch_tasks[self.name]
-			self.bld.fatal("Duplicated 'pch' task with name %r" % self.name)
+			task = self.bld.pch_tasks["%s.%s" % (self.name, self.idx)]
+			self.bld.fatal("Duplicated 'pch' task with name %r" % "%s.%s" % (self.name, self.idx))
 		except KeyError:
 			pass
 
@@ -104,7 +104,7 @@ def apply_pch(self):
 
 	self.pch_task = task
 	if getattr(self, 'name', None):
-		self.bld.pch_tasks[self.name] = task
+		self.bld.pch_tasks["%s.%s" % (self.name, self.idx)] = task
 
 @TaskGen.feature('cxx')
 @TaskGen.after_method('process_source', 'propagate_uselib_vars')


### PR DESCRIPTION
When shared library compiled with precompiled headers enabled, this
change prevents precompiled headers to activate on dependent targets.
Otherwise, there is an issue with -fPIC flag propagation.