### PR TITLE
Implement '__hash__' and '__eq__' methods on Node to make it dict-friendlier

### DIFF
--- a/waflib/Node.py
+++ b/waflib/Node.py
@@ -168,6 +168,12 @@ class Node(object):
 		"""
 		raise Errors.WafError('nodes are not supposed to be copied')
 
+	def __hash__(self):
+		return hash((self.name, self.parent))
+
+	def __eq__(self, other):
+		return (self.name, self.parent) == (other.name, other.parent)
+
 	def read(self, flags='r', encoding='latin-1'):
 		"""
 		Reads and returns the contents of the file represented by this node, see :py:func:`waflib.Utils.readf`::


### PR DESCRIPTION
Hi,

When node instances are used as key in a python dictionary the runtime environment is not always capable of retrieving them (I am using Python 2.7.8).

This has 2 consequences. The first is the less problematic one: in custom dictionary structures it is safer to use 'aNode.abspath()' to correctly index the dictionary and retrieve the corresponding node with 'Node.find_node()'. 
The second consequences is quite more subtle. The 'waflib.Build.store()' stores the 'node_sigs' dictionary in the Pickle DB and the 'waflib.Build.restore()' loads the pickle DB at the end of a Waf run in the 'node_sigs' on a successive builds. The python runtime environment is not always able to recognize the loaded nodes in the restored version of the 'node_sigs' structure thus causing the 'Task.runnable_status()' to return a 'RUN_ME' code because 'must run: an output node has no signature'.

This simple pull request implements the '__hash__()' and '__eq__()' methods in the 'waflib/Node.py' class to make it dictionary-friendlier.
