### PR TITLE
protoc: add .proto dependencies also in include path otherwise protoc will fail if dependency is in another directory

### DIFF
--- a/playground/protoc/incseparate/depinotherdir.proto
+++ b/playground/protoc/incseparate/depinotherdir.proto
@@ -1,0 +1,15 @@
+package udp.tc.tests;
+
+import "message_inc.proto";
+
+option java_package ="com.udp.tc.tests";
+option java_outer_classname= "MessageProtos";
+option cc_generic_services = false;
+option java_generic_services = false;
+option py_generic_services = false;
+
+message Message {
+    required int32 test = 1;
+    optional uint32 blah = 2;
+    required IncludeMe custom = 3;
+}

--- a/playground/protoc/wscript
+++ b/playground/protoc/wscript
@@ -16,8 +16,10 @@ def build(bld):
 	bld(
 		features = 'cxx cxxshlib',
 		source   = ['inc/message_inc.proto','inc/message.proto'],
+		name     = 'somelib',
 		target   = 'somelib',
-		includes = ['inc'])
+		includes = ['inc'],
+		export_includes = ['inc'])
 
 	bld(
 		features = 'cxx cxxshlib',
@@ -25,6 +27,12 @@ def build(bld):
 		target   = 'somedeeplib',
 		includes = ['incdeep'])
 
+	bld(
+		features = 'cxx cxxshlib',
+		source   = ['incseparate/depinotherdir.proto'],
+		target   = 'crossdirlib',
+		includes = ['incseparate'],
+		use      = ['somelib'])
 
 	bld(
 		features = 'py',

--- a/waflib/extras/protoc.py
+++ b/waflib/extras/protoc.py
@@ -124,6 +124,9 @@ class protoc(Task):
 							names.append(dep)
 
 		parse_node(node)
+		# Add also dependencies path to INCPATHS so protoc will find the included file
+		for deppath in nodes:
+			self.env.append_value('INCPATHS', deppath.parent.bldpath())
 		return (nodes, names)
 
 @extension('.proto')


### PR DESCRIPTION

protoc extra already correctly had the scanner for dependencies and would build dependent .proto files. But if the dependency is in another directory then also the include path to that directory has to be passed to protoc via -I otherwise the file will not be found and execution will fail.

Added also a small example in protoc playground.
