### PR TITLE
eclipse: correct feature name to javac not java

### DIFF
--- a/waflib/extras/eclipse.py
+++ b/waflib/extras/eclipse.py
@@ -86,7 +86,7 @@ class eclipse(Build.BuildContext):
 
 
 				# Add Java source directories so object resolving works in IDE
-				if 'java' in tg.features:
+				if 'javac' in tg.features:
 					java_src = tg.path.relpath()
 					java_srcdir = getattr(tg, 'srcdir', None)
 					if java_srcdir:


### PR DESCRIPTION
it was actually working anyway if the features were passed as a string (as in the playground example) but not if passed as a list