### PR TITLE
pyqt5: improve the sample in playground so can easily work also with pyside2

### DIFF
--- a/playground/pyqt5/src/sample.py
+++ b/playground/pyqt5/src/sample.py
@@ -1,5 +1,9 @@
 import sys
+# If pyqt5 bindings are used uncomment the following line:
 from PyQt5 import QtCore, QtGui, QtWidgets
+# If pyside2 bindings are used uncomment the following line:
+#from PySide2 import QtCore, QtGui, QtWidgets
+
 from firstgui import Ui_myfirstgui
 
 class MyFirstGuiProgram(Ui_myfirstgui):


### PR DESCRIPTION

Minor change to playground example so it is trivial to make it work also with pyside2 (if pyside2 is auto-detected instead of pyqt5 or if it is forced with --pyqt5-pyside2 at waf configure)