### PR TITLE
eclipse: generate an external builder when no CDT is used in the project

### DIFF
--- a/playground/eclipse/wscript
+++ b/playground/eclipse/wscript
@@ -23,7 +23,12 @@ This will generate the needed configuration files for Eclipse:
 -) .project is generic Eclipse project file
 -) .cproject for C/C++ CDT
 -) .classpath for Java JDT
--) .pydevproject for Pydev)
+-) .pydevproject for Pydev
+
+If CDT is in the project (so at least one C/C++ build) then CDT builder
+will be used to call waf as it is more versatile. If just JDT/PYydev are
+used then an Eclipse external builder is defined that calls waf. This is
+created in the file .externalToolBuilders/Waf_Builder.launch.
 
 The example contains three directories with different supported languages
 to demonstrate the features working for each of them, most importantly the
@@ -33,6 +38,9 @@ Eclipse by hand using Project->Properties and then each language menu.
 
 Also the generic invocation for building and cleaning are redefined so
 waf is called correctly when the respective actions are requested.
+
+To test just the external builder definition just remove "c" from the
+module_list below.
 """
 
 

--- a/waflib/extras/eclipse.py
+++ b/waflib/extras/eclipse.py
@@ -178,7 +178,7 @@ class eclipse(Build.BuildContext):
 			# Otherwise for Java/Python an external builder tool is created that will call waf build
 			self.add(doc, buildCommand, 'name', 'org.eclipse.ui.externaltools.ExternalToolBuilder')
 			dictionaries = {
-					'LaunchConfigHandle': '<project>/' + extbuilder_dir + '/'+extbuilder_name,
+					'LaunchConfigHandle': '<project>/%s/%s'%(extbuilder_dir, extbuilder_name),
 					}
 			# The definition is in a separate directory XML file
 			try:
@@ -198,7 +198,7 @@ class eclipse(Build.BuildContext):
 			self.add(doc, launchConfiguration, 'stringAttribute', {'key': 'org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY', 'value': '${project_loc}'})
 			builder.appendChild(launchConfiguration)
 			# And write the XML to the file references before
-			self.srcnode.make_node(extbuilder_dir + os.path.sep + extbuilder_name).write(builder.toprettyxml())
+			self.srcnode.make_node('%s%s%s'%(extbuilder_dir, os.path.sep, extbuilder_name)).write(builder.toprettyxml())
 
 		for k, v in dictionaries.items():
 			self.addDictionary(doc, arguments, k, v)

--- a/waflib/extras/eclipse.py
+++ b/waflib/extras/eclipse.py
@@ -23,6 +23,8 @@ oe_cdt = 'org.eclipse.cdt'
 cdt_mk = oe_cdt + '.make.core'
 cdt_core = oe_cdt + '.core'
 cdt_bld = oe_cdt + '.build.core'
+extbuilder_dir = '.externalToolBuilders'
+extbuilder_name = 'Waf_Builder.launch'
 
 class eclipse(Build.BuildContext):
 	cmd = 'eclipse'
@@ -134,11 +136,11 @@ class eclipse(Build.BuildContext):
 
 					hasc = True
 
-		project = self.impl_create_project(sys.executable, appname, hasc, hasjava, haspython)
+		waf = os.path.abspath(sys.argv[0])
+		project = self.impl_create_project(sys.executable, appname, hasc, hasjava, haspython, waf)
 		self.srcnode.make_node('.project').write(project.toprettyxml())
 
 		if hasc:
-			waf = os.path.abspath(sys.argv[0])
 			project = self.impl_create_cproject(sys.executable, waf, appname, workspace_includes, cpppath, source_dirs)
 			self.srcnode.make_node('.cproject').write(project.toprettyxml())
 
@@ -150,7 +152,7 @@ class eclipse(Build.BuildContext):
 			project = self.impl_create_javaproject(javasrcpath, javalibpath)
 			self.srcnode.make_node('.classpath').write(project.toprettyxml())
 
-	def impl_create_project(self, executable, appname, hasc, hasjava, haspython):
+	def impl_create_project(self, executable, appname, hasc, hasjava, haspython, waf):
 		doc = Document()
 		projectDescription = doc.createElement('projectDescription')
 		self.add(doc, projectDescription, 'name', appname)
@@ -158,16 +160,46 @@ class eclipse(Build.BuildContext):
 		self.add(doc, projectDescription, 'projects')
 		buildSpec = self.add(doc, projectDescription, 'buildSpec')
 		buildCommand = self.add(doc, buildSpec, 'buildCommand')
-		self.add(doc, buildCommand, 'name', oe_cdt + '.managedbuilder.core.genmakebuilder')
 		self.add(doc, buildCommand, 'triggers', 'clean,full,incremental,')
 		arguments = self.add(doc, buildCommand, 'arguments')
-		# the default make-style targets are overwritten by the .cproject values
-		dictionaries = {
-				cdt_mk + '.contents': cdt_mk + '.activeConfigSettings',
-				cdt_mk + '.enableAutoBuild': 'false',
-				cdt_mk + '.enableCleanBuild': 'true',
-				cdt_mk + '.enableFullBuild': 'true',
-				}
+		dictionaries = {}
+
+		# If CDT is present, instruct this one to call waf as it is more flexible (separate build/clean ...)
+		if hasc:
+			self.add(doc, buildCommand, 'name', oe_cdt + '.managedbuilder.core.genmakebuilder')
+			# the default make-style targets are overwritten by the .cproject values
+			dictionaries = {
+					cdt_mk + '.contents': cdt_mk + '.activeConfigSettings',
+					cdt_mk + '.enableAutoBuild': 'false',
+					cdt_mk + '.enableCleanBuild': 'true',
+					cdt_mk + '.enableFullBuild': 'true',
+					}
+		else:
+			# Otherwise for Java/Python an external builder tool is created that will call waf build
+			self.add(doc, buildCommand, 'name', 'org.eclipse.ui.externaltools.ExternalToolBuilder')
+			dictionaries = {
+					'LaunchConfigHandle': '<project>/' + extbuilder_dir + '/'+extbuilder_name,
+					}
+			# The definition is in a separate directory XML file
+			try:
+				os.mkdir(extbuilder_dir)
+			except OSError:
+				pass	# Ignore error if already exists
+
+			# Populate here the external builder XML calling waf
+			builder = Document()
+			launchConfiguration = doc.createElement('launchConfiguration')
+			launchConfiguration.setAttribute('type', 'org.eclipse.ui.externaltools.ProgramBuilderLaunchConfigurationType')
+			self.add(doc, launchConfiguration, 'booleanAttribute', {'key': 'org.eclipse.debug.ui.ATTR_LAUNCH_IN_BACKGROUND', 'value': 'false'})
+			self.add(doc, launchConfiguration, 'booleanAttribute', {'key': 'org.eclipse.ui.externaltools.ATTR_TRIGGERS_CONFIGURED', 'value': 'true'})
+			self.add(doc, launchConfiguration, 'stringAttribute', {'key': 'org.eclipse.ui.externaltools.ATTR_LOCATION', 'value': waf})
+			self.add(doc, launchConfiguration, 'stringAttribute', {'key': 'org.eclipse.ui.externaltools.ATTR_RUN_BUILD_KINDS', 'value': 'full,incremental,'})
+			self.add(doc, launchConfiguration, 'stringAttribute', {'key': 'org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS', 'value': 'build'})
+			self.add(doc, launchConfiguration, 'stringAttribute', {'key': 'org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY', 'value': '${project_loc}'})
+			builder.appendChild(launchConfiguration)
+			# And write the XML to the file references before
+			self.srcnode.make_node(extbuilder_dir + os.path.sep + extbuilder_name).write(builder.toprettyxml())
+
 		for k, v in dictionaries.items():
 			self.addDictionary(doc, arguments, k, v)
 


### PR DESCRIPTION
When CDT is not included in the project (ie. we just have Python and/or Java) the current implementation would not create automatically a call to waf for the build stage. This patch adds in such cases an external builder that automates the call to waf without the need to manually configure one.