### PR TITLE
Don't quote or escape arg file lines for moc/rcc

### DIFF
--- a/waflib/Tools/qt5.py
+++ b/waflib/Tools/qt5.py
@@ -395,12 +395,38 @@ class rcc(Task.Task):
 				names.append(x)
 		return (nodes, names)
 
+	def quote_flag(self, x):
+		"""
+		Override Task.quote_flag. QT parses the argument files
+		differently than cl.exe and link.exe
+
+		:param x: flag
+		:type x: string
+		:return: quoted flag
+		:rtype: string
+		"""
+		return x
+
+
 class moc(Task.Task):
 	"""
 	Creates ``.moc`` files
 	"""
 	color   = 'BLUE'
 	run_str = '${QT_MOC} ${MOC_FLAGS} ${MOCCPPPATH_ST:INCPATHS} ${MOCDEFINES_ST:DEFINES} ${SRC} ${MOC_ST} ${TGT}'
+
+	def quote_flag(self, x):
+		"""
+		Override Task.quote_flag. QT parses the argument files
+		differently than cl.exe and link.exe
+
+		:param x: flag
+		:type x: string
+		:return: quoted flag
+		:rtype: string
+		"""
+		return x
+
 
 class ui5(Task.Task):
 	"""


### PR DESCRIPTION
Qt parses argument files differently than cl.exe or link.exe, see https://github.com/qt/qtbase/blob/5.11/src/tools/moc/main.cpp#L141. Avoiding the quoting and escaping from Task.quote_flag saves one from "too many files specified" moc/rcc error when command-line string is longer than 8191 character limit.