### PR TITLE
Add env variable to skip Qt5 auto configuration

### DIFF
--- a/waflib/Tools/qt5.py
+++ b/waflib/Tools/qt5.py
@@ -451,6 +451,9 @@ def configure(self):
 	if 'COMPILER_CXX' not in self.env:
 		self.fatal('No CXX compiler defined: did you forget to configure compiler_cxx first?')
 
+	if self.env.NO_QT5_DETECT:
+		return
+
 	# Qt5 may be compiled with '-reduce-relocations' which requires dependent programs to have -fPIE or -fPIC?
 	frag = '#include <QApplication>\nint main(int argc, char **argv) {return 0;}\n'
 	uses = 'QT5CORE QT5WIDGETS QT5GUI'


### PR DESCRIPTION
This allows one to avoid calling the check method which modifies some env variables, for example CPPFLAGS. This also allows one to avoid using the compiler flags below which are invalid for msvc.